### PR TITLE
Ensures that plural blocks always have two empty strings as msgstr - …

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -214,6 +214,10 @@ export const getTraverser = (cb = noop, opts = {}) => {
           .filter(x => x)
           .reduce((a, b) => ({ ...a, ...b }), getEmptyBlock());
 
+        if (block.msgid_plural) {
+          block.msgstr = ['', ''];
+        }
+
         if (envOpts.filename) {
           block.comments.reference = [`${envOpts.filename}:${node.loc.start.line}`];
         }

--- a/tests/fixtures/CustomComponent.jsx
+++ b/tests/fixtures/CustomComponent.jsx
@@ -1,6 +1,6 @@
 
 import React from 'react';
-import { T, translate } from 'gettext-lib';
+import { T } from 'gettext-lib';
 
 const CustomComponent = () =>
   <div>

--- a/tests/fixtures/Plurals.js
+++ b/tests/fixtures/Plurals.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import { GetText, ngettext } from 'gettext-lib';
+
+const ItemCount = ({ numItems }) =>
+  <div>
+    { ngettext("One item", "{{ count }} items", numItems) }
+    <GetText message="Go to item" messagePlural="Go to items" count={numItems} />
+  </div>;
+
+export default ItemCount;

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -49,6 +49,21 @@ describe('react-gettext-parser', () => {
 
   });
 
+  describe('plural extraction', () => {
+
+    it('extracts plural blocks from both function calls and components', () => {
+      const code = getSource('Plurals.js');
+      const messages = extractMessages(code);
+
+      expect(messages).to.have.length(2);
+      expect(messages[0].msgid_plural).to.not.be.empty;
+      expect(messages[0].msgstr).to.eql(['', '']);
+      expect(messages[1].msgid_plural).to.not.be.empty;
+      expect(messages[1].msgstr).to.eql(['', '']);
+    });
+
+  });
+
   describe('customization', () => {
 
     it('should parse strings from custom jsx components', () => {


### PR DESCRIPTION
…fixes #6 