### PR TITLE
Parse comments as extracted-comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Results in something like:
     msgid: "Translate me"
     msgstr: [""],
     comments: {
-      translator: ["A comment to translators"],
+      extracted: ["A comment to translators"],
       reference: ["MyComponent.jsx:13"]
     }
   },

--- a/src/json2pot.js
+++ b/src/json2pot.js
@@ -34,7 +34,7 @@ const convertCommentArraysToStrings = (blocks) =>
     ...b,
     comments: {
       reference: b.comments.reference.join('\n'),
-      translator: b.comments.translator.join('\n'),
+      extracted: b.comments.extracted.join('\n'),
     },
   }));
 

--- a/src/parse.js
+++ b/src/parse.js
@@ -19,7 +19,7 @@ const getEmptyBlock = () => ({
   msgstr: [''],
   comments: {
     reference: [],
-    translator: [],
+    extracted: [],
   },
 });
 
@@ -54,7 +54,7 @@ const getGettextBlockFromComponent = (propsMap, node) => {
         currBlock.msgctxt = value;
       }
       else if (gettextVar === 'comment') {
-        currBlock.comments.translator.push(value);
+        currBlock.comments.extracted.push(value);
       }
 
       return currBlock;
@@ -82,8 +82,8 @@ export const getUniqueBlocks = blocks =>
 
     if (existingBlock) {
       // Concatenate comments to translators
-      if (block.comments.translator.length > 0) {
-        existingBlock.comments.translator = uniq(existingBlock.comments.translator.concat(block.comments.translator));
+      if (block.comments.extracted.length > 0) {
+        existingBlock.comments.extracted = uniq(existingBlock.comments.extracted.concat(block.comments.extracted));
       }
 
       // Concatenate source references

--- a/tests/fixtures/SingleString.json
+++ b/tests/fixtures/SingleString.json
@@ -4,7 +4,7 @@
     "msgid": "Translate me",
     "comments": {
       "reference": [],
-      "translator": []
+      "extracted": []
     }
   }
 ]

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -63,7 +63,7 @@ describe('react-gettext-parser', () => {
       expect(messages[0].msgctxt).to.eql('context');
       expect(messages[0].msgid).to.eql('Value is: {{ value }}');
       expect(messages[0].msgid_plural).to.eql('Values are: {{ value }}');
-      expect(messages[0].comments.translator[0]).to.eql('Comment');
+      expect(messages[0].comments.extracted[0]).to.eql('Comment');
 
       expect(messages[1].msgctxt).to.eql('context');
       expect(messages[1].msgid).to.eql('One thing');


### PR DESCRIPTION
When comments are pulled from components, they are added as translator comments to the PO file. This should be changed to _extracted_ comments.

In `README.md` the comments are described as _"A comment to translators"_. In `gettext` the `translator-comments` are comments _from_ the translators. Comments _to_ the translators should be added as `extracted-comments`.

From [The Format of PO Files](https://www.gnu.org/software/gettext/manual/html_node/PO-Files.html):

> Comment lines starting with #. contain comments given by the programmer, directed at the translator; these comments are called extracted comments

> \# - the translator comments -, which [...] are created and maintained exclusively by the translator

This is especially evident when creating a new `.po` file based on a `.pot` file using `msginit`: `extracted-comments` are copied over to the `.po` file while `translator-comments` are not.
