### PR TITLE
Don't fail on missing msgid

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -76,7 +76,7 @@ export const areBlocksEqual = curry((a, b) =>
  * concatenated.
  */
 export const getUniqueBlocks = blocks =>
-  blocks.filter(x => x.msgid.trim()).reduce((unique, block) => {
+  blocks.filter(x => x.msgid && x.msgid.trim()).reduce((unique, block) => {
     const isEqualBlock = areBlocksEqual(block);
     const existingBlock = unique.filter(x => isEqualBlock(x)).shift();
 

--- a/tests/fixtures/NonStatic.js
+++ b/tests/fixtures/NonStatic.js
@@ -1,0 +1,57 @@
+import React from 'react';
+import { GetText, gt } from 'gettext-lib';
+
+const messageString = "Translate me";
+const messageFunction = () => "Translate me";
+const MessageComponent = () => <div>Translate me</div>;
+
+
+const NonStatic = () =>
+  <div>
+    <GetText message={messageString} messagePlural="" />
+    <GetText message={messageString} messagePlural="non-empty plural" count={2} context="context" />
+    
+    <GetText message={messageFunction()} messagePlural="" />
+    <GetText message={messageFunction()} messagePlural="non-empty plural" count={2} context="context" />
+    
+    <GetText message={<MessageComponent />} messagePlural="" />
+    <GetText message={<MessageComponent />} messagePlural="non-empty plural" count={2} context="context" />
+
+    {gt.gettext(messageString)}
+    {gt.ngettext(messageString, messageString, 2)}
+    {gt.ngettext(messageString, messageString, 2)}
+    {gt.ngettext(messageString, 'non-empty plural', 2)}
+    {gt.pgettext('context', messageString)}
+    {gt.npgettext('context', messageString, messageString, 2)}
+    {gt.npgettext('context', messageString, 'non-empty plural', 2)}
+    {gt.dgettext('domain', messageString)}
+    {gt.dpgettext('domain', 'context', messageString)}
+    {gt.dnpgettext('domain', 'context', messageString, messageString, 2)}
+    {gt.dnpgettext('domain', 'context', messageString, 'non-empty plural', 2)}
+
+    {gt.gettext(messageFunction())}
+    {gt.ngettext(messageFunction(), messageFunction(), 2)}
+    {gt.ngettext(messageFunction(), messageFunction(), 2)}
+    {gt.ngettext(messageFunction(), 'non-empty plural', 2)}
+    {gt.pgettext('context', messageFunction())}
+    {gt.npgettext('context', messageFunction(), messageFunction(), 2)}
+    {gt.npgettext('context', messageFunction(), 'non-empty plural', 2)}
+    {gt.dgettext('domain', messageFunction())}
+    {gt.dpgettext('domain', 'context', messageFunction())}
+    {gt.dnpgettext('domain', 'context', messageFunction(), messageFunction(), 2)}
+    {gt.dnpgettext('domain', 'context', messageFunction(), 'non-empty plural', 2)}
+
+    {gt.gettext(<MessageComponent />)}
+    {gt.ngettext(<MessageComponent />, <MessageComponent />, 2)}
+    {gt.ngettext(<MessageComponent />, <MessageComponent />, 2)}
+    {gt.ngettext(<MessageComponent />, 'non-empty plural', 2)}
+    {gt.pgettext('context', <MessageComponent />)}
+    {gt.npgettext('context', <MessageComponent />, <MessageComponent />, 2)}
+    {gt.npgettext('context', <MessageComponent />, 'non-empty plural', 2)}
+    {gt.dgettext('domain', <MessageComponent />)}
+    {gt.dpgettext('domain', 'context', <MessageComponent />)}
+    {gt.dnpgettext('domain', 'context', <MessageComponent />, <MessageComponent />, 2)}
+    {gt.dnpgettext('domain', 'context', <MessageComponent />, 'non-empty plural', 2)}
+  </div>;
+
+export default NonStatic;

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -54,6 +54,13 @@ describe('react-gettext-parser', () => {
       expect(messages).to.have.length(0);
     });
 
+    it('should ignore non-static messages', () => {
+      const code = getSource('NonStatic.js');
+      const messages = extractMessages(code);
+
+      expect(messages).to.have.length(0);
+    });
+
     it('should support es6 template strings', () => {
       const code = getSource('Es6Strings.js');
       const messages = extractMessages(code);


### PR DESCRIPTION
When one of the `componentPropsMap` components is used _without_ the parameter defined to contain the `msgid`, the parser fails. Since `msgid` is `null` when not defined, calling `.trim` on it will raise an exception:

```
Module build failed: TypeError: /src/MyComponent.js: Cannot read property 'trim' of null
    at /node_modules/react-gettext-parser/lib/parse.js:111:19
    at Array.filter (native)
    at getUniqueBlocks (/node_modules/react-gettext-parser/lib/parse.js:110:17)
    at PluginPass.exit (/node_modules/react-gettext-parser/lib/parse.js:175:12)
    at newFn (/node_modules/babel-traverse/lib/visitors.js:276:21)
    at NodePath._call (/node_modules/babel-traverse/lib/path/context.js:76:18)
    at NodePath.call (/node_modules/babel-traverse/lib/path/context.js:48:17)
    at NodePath.visit (/node_modules/babel-traverse/lib/path/context.js:117:8)
    at TraversalContext.visitQueue (/node_modules/babel-traverse/lib/context.js:150:16)
    at TraversalContext.visitSingle (/node_modules/babel-traverse/lib/context.js:108:19)
    at TraversalContext.visit (/node_modules/babel-traverse/lib/context.js:192:19)
    at Function.traverse.node (/node_modules/babel-traverse/lib/index.js:114:17)
```