### PR TITLE
Supports replacing new-lines with a custom string

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -266,9 +266,10 @@ export const extractMessages = (code, opts = {}) => {
     }));
   }
   if (opts.trimNewlines) {
+    const replaceValue = typeof opts.trimNewlines === 'string' ? opts.trimNewlines : '';
     blocks = blocks.map(block => ({
       ...block,
-      msgid: block.msgid.replace(/\n/g, ''),
+      msgid: block.msgid.replace(/\n/g, replaceValue),
     }));
   }
 

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -137,6 +137,14 @@ describe('react-gettext-parser', () => {
         expect(messages[0].msgid).to.equal('      A      B      C    ');
       });
 
+      it('new-lines, replaced by a custom character when it is a string', () => {
+        const messages = extractMessagesFromFile('tests/fixtures/Whitespace.jsx', {
+          trimNewlines: 'x',
+        });
+
+        expect(messages[0].msgid).to.equal('x      Ax      Bx      Cxxx    ');
+      });
+
       it('whitespace from each line\'s start and end when trimLines is true', () => {
         const messages = extractMessagesFromFile('tests/fixtures/Whitespace.jsx', {
           trimLines: true,


### PR DESCRIPTION
Say you have the following component:

```js
import { T } from 'lioness'

const Thingy = () => (
  <T>
    Readymade intelligentsia lumbersexual raw denim. DIY occupy poke, 
    synth man bun waistcoat migas mixtape street art vape mumblecore.
  </T>
)
```

This is how [`prettier`](https://github.com/prettier/prettier) will format a long chunk of text inside a component.

The three trimming options does not make it possible to extract that string as one continuous sentence with no extra white space. Enabling all of them will result in an ugly concatenation: *[...] poke,synth [...]*.

By making `trimNewlines` accept a string as a custom replacement, we can achieve this.