### PR TITLE
Set comment reference as object contains filename, line and column

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,11 @@ Results in something like:
     msgstr: [""],
     comments: {
       extracted: ["A comment to translators"],
-      reference: ["MyComponent.jsx:13"]
+      reference: [{
+        filename:"MyComponent.jsx",
+        line:13,
+        column:1
+      }]
     }
   },
   // And so on...

--- a/src/json2pot.js
+++ b/src/json2pot.js
@@ -29,11 +29,13 @@ const createTranslationsTable = (blocks, headers = {}) => {
   };
 };
 
+const convertReferenceToString = reference => `${reference.filename}:${reference.line}`;
+
 const convertCommentArraysToStrings = (blocks) =>
   blocks.map(b => ({
     ...b,
     comments: {
-      reference: b.comments.reference.join('\n'),
+      reference: b.comments.reference.map(ref => convertReferenceToString(ref)).join('\n'),
       extracted: b.comments.extracted.join('\n'),
     },
   }));

--- a/src/parse.js
+++ b/src/parse.js
@@ -72,7 +72,7 @@ export const areBlocksEqual = curry((a, b) =>
 /**
  * Returns whether two gettext reference comment are considered equal
  */
-const areReferenceEqual = curry((a, b) =>
+const areReferencesEqual = curry((a, b) =>
   (a.filename === b.filename && a.line === b.line && a.column === b.column)
 );
 
@@ -106,7 +106,7 @@ export const getUniqueBlocks = blocks =>
       if (block.comments.reference.length > 0) {
         existingBlock.comments.reference = uniq(existingBlock.comments.reference
             .concat(block.comments.reference),
-            areReferenceEqual)
+            areReferencesEqual)
           .sort(compareReference);
       }
 
@@ -321,7 +321,7 @@ export const extractMessagesFromFile = (file, opts = {}) =>
 export const extractMessagesFromGlob = (globArr, opts = {}) => {
   const blocks = glob.sync(globArr)
     .reduce((all, file) => all.concat(extractMessagesFromFile(file, opts)), []);
-
+    
   return getUniqueBlocks(blocks);
 };
 

--- a/tests/fixtures/DuplicatedStrings.jsx
+++ b/tests/fixtures/DuplicatedStrings.jsx
@@ -1,0 +1,13 @@
+
+import React from 'react';
+import { GetText, npgettext } from 'gettext-lib';
+
+const DuplicatedStrings = () =>
+  <div>
+    <div>
+      <GetText message="I'm occur twice" />
+    </div>
+    <GetText message="I'm occur twice" />
+  </div>;
+
+export default DuplicatedStrings;

--- a/tests/fixtures/MergeA.jsx
+++ b/tests/fixtures/MergeA.jsx
@@ -5,7 +5,6 @@ import { GetText } from 'gettext-lib';
 const MergeA = () =>
   <div>
     <GetText message="I'm both here and elsewhere" />
-    <GetText message="I'm both here and elsewhere" />
   </div>;
 
 export default MergeA;

--- a/tests/fixtures/MergeA.jsx
+++ b/tests/fixtures/MergeA.jsx
@@ -5,6 +5,7 @@ import { GetText } from 'gettext-lib';
 const MergeA = () =>
   <div>
     <GetText message="I'm both here and elsewhere" />
+    <GetText message="I'm both here and elsewhere" />
   </div>;
 
 export default MergeA;

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -188,24 +188,26 @@ describe('react-gettext-parser', () => {
     it('should merge two identical strings and concatenate references', () => {
       const messages = extractMessagesFromGlob('tests/fixtures/Merge{A,B}.jsx');
       expect(messages).to.have.length(1);
-      expect(messages[0].comments.reference).to.have.length(2);
+      expect(messages[0].comments.reference).to.have.length(3);
     });
 
     it('should merge identical strings independant of jsx or js', () => {
       const messages = extractMessagesFromGlob('tests/fixtures/Merge{A,C}.jsx');
       expect(messages).to.have.length(1);
-      expect(messages[0].comments.reference).to.have.length(2);
+      expect(messages[0].comments.reference).to.have.length(3);
     });
 
-    it('should sort references alphabetically', () => {
+    it('should sort references alphabetically with line and col order', () => {
       const messages = extractMessagesFromGlob('tests/fixtures/Merge*.jsx');
       expect(messages).to.have.length(1);
 
       const references = messages[0].comments.reference;
-      expect(references).to.have.length(3);
-      expect(references[0]).to.contain('MergeA.jsx');
-      expect(references[1]).to.contain('MergeB.jsx');
-      expect(references[2]).to.contain('MergeC.jsx');
+      expect(references).to.have.length(4);
+      expect(references[0].filename).to.contain('MergeA.jsx');
+      expect(references[1].filename).to.contain('MergeA.jsx');
+      expect(references[2].filename).to.contain('MergeB.jsx');
+      expect(references[3].filename).to.contain('MergeC.jsx');
+      expect(references[0].line).to.below(references[1].line);
     });
 
   });

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -180,34 +180,52 @@ describe('react-gettext-parser', () => {
         expect(messages[0].msgid).to.equal('A\nB\nC');
       });
     });
+  });
 
+  describe('line and column number', () => {
+    it('should have line and column', () => {
+      const messages = extractMessagesFromFile('tests/fixtures/SingleString.js');
+      expect(messages).to.have.length(1);
+      const references = messages[0].comments.reference;
+      expect(references[0].line).to.equal(7);
+      expect(references[0].column).to.equal(6);
+    });
+
+    it('should sort with line and column order', () => {
+      const messages = extractMessagesFromFile('tests/fixtures/DuplicatedStrings.jsx');
+      expect(messages).to.have.length(1);
+
+      const references = messages[0].comments.reference;
+      expect(references).to.have.length(2);
+      expect(references[0].line).to.equal(8);
+      expect(references[1].line).to.equal(10);
+      expect(references[0].column).to.equal(6);
+      expect(references[1].column).to.equal(4);
+    });
   });
 
   describe('merging identical strings', () => {
-
     it('should merge two identical strings and concatenate references', () => {
       const messages = extractMessagesFromGlob('tests/fixtures/Merge{A,B}.jsx');
       expect(messages).to.have.length(1);
-      expect(messages[0].comments.reference).to.have.length(3);
+      expect(messages[0].comments.reference).to.have.length(2);
     });
 
     it('should merge identical strings independant of jsx or js', () => {
       const messages = extractMessagesFromGlob('tests/fixtures/Merge{A,C}.jsx');
       expect(messages).to.have.length(1);
-      expect(messages[0].comments.reference).to.have.length(3);
+      expect(messages[0].comments.reference).to.have.length(2);
     });
 
-    it('should sort references alphabetically with line and col order', () => {
+    it('should sort references alphabetically', () => {
       const messages = extractMessagesFromGlob('tests/fixtures/Merge*.jsx');
       expect(messages).to.have.length(1);
 
       const references = messages[0].comments.reference;
-      expect(references).to.have.length(4);
+      expect(references).to.have.length(3);
       expect(references[0].filename).to.contain('MergeA.jsx');
-      expect(references[1].filename).to.contain('MergeA.jsx');
-      expect(references[2].filename).to.contain('MergeB.jsx');
-      expect(references[3].filename).to.contain('MergeC.jsx');
-      expect(references[0].line).to.below(references[1].line);
+      expect(references[1].filename).to.contain('MergeB.jsx');
+      expect(references[2].filename).to.contain('MergeC.jsx');
     });
 
   });
@@ -246,5 +264,5 @@ describe('react-gettext-parser', () => {
     });
 
   });
-
+  
 });


### PR DESCRIPTION
I have dynamically generated code which is trimmed. I found it is useful to also have a column number in the reference object.

I still keep the output .po(t) file contains only line number.