### PR TITLE
Adds support for React children strings inside JSX expressions

### DIFF
--- a/tests/fixtures/JsxValueStrings.jsx
+++ b/tests/fixtures/JsxValueStrings.jsx
@@ -1,0 +1,11 @@
+
+import React from 'react';
+import { GetText } from 'gettext-lib';
+
+const JsxValueStrings = () =>
+  <div>
+    <GetText>{'I\'m inside curly braces'}</GetText>
+    <GetText>{`I'm inside backticks inside curly braces`}</GetText>
+  </div>;
+
+export default JsxValueStrings;

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -78,6 +78,15 @@ describe('react-gettext-parser', () => {
       expect(messages[1].msgid_plural).to.eql('Many things');
     });
 
+    it('should support React children strings wrapped in JSX expressions', () => {
+      const code = getSource('JsxValueStrings.jsx');
+      const messages = extractMessages(code);
+
+      expect(messages).to.have.length(2);
+      expect(messages[0].msgid).to.equal(`I'm inside curly braces`);
+      expect(messages[1].msgid).to.equal(`I'm inside backticks inside curly braces`);
+    });
+
   });
 
   describe('plural extraction', () => {
@@ -265,5 +274,5 @@ describe('react-gettext-parser', () => {
     });
 
   });
-  
+
 });

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -1,6 +1,7 @@
-/* global describe it */
+/* eslint-env mocha */
+/* eslint no-unused-expressions: 0 */
 
-import { assert, expect } from 'chai';
+import { expect } from 'chai';
 import { spy } from 'sinon';
 import { po } from 'gettext-parser';
 import fs from 'fs';


### PR DESCRIPTION
Child strings wrapped in JSX expressions (curly braces) are now supported:

```jsx
// String literals
<TranslateThis>
  {'There is a custom template variable with value: {value}'}
</TranslateThis>

// Template strings
<TranslateThis>
  {`Another example: {value}`}
</TranslateThis>
```

Resolves #27.