### PR TITLE
Extracts leading 'Translators: ...' comments from function calls

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -226,7 +226,7 @@ export const getTraverser = (cb = noop, opts = {}) => {
      */
     CallExpression: {
       enter(path, state = {}) {
-        const { node } = path;
+        const { node, parent } = path;
         const envOpts = state.opts || opts;
 
         const funcArgsMap = envOpts.funcArgumentsMap || GETTEXT_FUNC_ARGS_MAP;
@@ -250,6 +250,26 @@ export const getTraverser = (cb = noop, opts = {}) => {
 
         if (block.msgid_plural) {
           block.msgstr = ['', ''];
+        }
+
+        // Extract comments for translators
+        if (Array.isArray(parent.leadingComments) === true) {
+          const translatorCommentRegex = /Translators:.+/;
+          const commentNode = parent.leadingComments.find(x => translatorCommentRegex.test(x.value) === true);
+
+          if (commentNode !== undefined) {
+            const commentLine = commentNode.value
+              .split(/\n/)
+              .find(x => translatorCommentRegex.test(x));
+
+            if (commentLine !== undefined) {
+              const comment = commentLine
+                .replace(/^\s*\*/, '')
+                .replace(/Translators:/, '')
+                .trim();
+              block.comments.extracted = [comment];
+            }
+          }
         }
 
         if (envOpts.filename) {

--- a/tests/fixtures/FunctionWithComment.js
+++ b/tests/fixtures/FunctionWithComment.js
@@ -1,0 +1,14 @@
+import { gettext } from 'gettext';
+
+// Translators: A comment to translators
+gettext('wow');
+
+/*
+ Translators:Instructions inside multi-line comment
+ */
+gettext('ok');
+
+/**
+ * Translators:    Instructions inside block comment
+ */
+gettext('dokes');

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -41,6 +41,15 @@ describe('react-gettext-parser', () => {
       expect(messages[0].msgid).to.equal(expected[0].msgid);
     });
 
+    it('should extract translators\' comment attached to function call', () => {
+      const code = getSource('FunctionWithComment.js');
+      const messages = extractMessages(code);
+
+      expect(messages[0].comments.extracted[0]).to.equal('A comment to translators');
+      expect(messages[1].comments.extracted[0]).to.equal('Instructions inside multi-line comment');
+      expect(messages[2].comments.extracted[0]).to.equal('Instructions inside block comment');
+    });
+
     it('should do nothing when no strings are found', () => {
       const code = getSource('NoStrings.js');
       const messages = extractMessages(code);


### PR DESCRIPTION
This lets you provide translators with a comment using regular JavaScript comments.

#### app.js

```js
import { gettext } from 'gettext'

// Translators: A comment to translators
gettext('wow')

/*
 Translators: Instructions inside multi-line comment
 */
gettext('ok')

/**
 * Translators: Instructions inside block comment
 */
gettext('dokes')
```

#### Resulting POT

```gettext
#: app.js:4
#. A comment to translators
msgid "wow"
msgstr ""

#: app.js:9
#. Instructions inside multi-line comment
msgid "ok"
msgstr ""

#: app.js:14
#. Instructions inside block comment
msgid "dokes"
msgstr ""
```