### PR TITLE
add typescript support

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,8 @@
 {
-  "presets": ["es2015"],
-  "plugins": ["transform-object-rest-spread"]
+  "presets": [
+    "@babel/preset-env"
+  ],
+  "plugins": [
+    "@babel/plugin-proposal-object-rest-spread"
+  ]
 }

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ It can be used directly in JavaScript, in gulp, [via babel](https://github.com/a
 
 ## Features
 
-* Extracts translatable strings from JSX and JavaScript (obsviously)
+* Extracts translatable strings from JSX, JavaScript as well as Typescript (obsviously)
 * Maps component names and properties to gettext variables (configurable)
 * Maps function names and arguments to gettext variables (configurable)
 * Merges identical strings found in separate files and concatenates their references
@@ -30,7 +30,7 @@ It can be used directly in JavaScript, in gulp, [via babel](https://github.com/a
 Providing a config, using a single glob string:
 
 ```sh
-react-gettext-parser --config path/to/config.js --output messages.pot 'src/**/{*.js,*.jsx}'
+react-gettext-parser --config path/to/config.js --output messages.pot 'src/**/{*.js,*.jsx,*.ts,*.tsx}'
 ```
 
 Using an array of glob strings, which is passed to [`glob-all`](https://www.npmjs.com/package/glob-all):
@@ -141,19 +141,21 @@ gulp.task('build:pot', function() {
 
 ##### `extractMessages(codeStr, [options])`
 
-Parses a string with JS(X) source code for translatable strings and returns a list of message objects.
+Parses a string with JS(X) or Typescript source code for translatable strings and returns a list of message objects.
+When use with typescript source code, specify option `sourceType` as `TYPESCRIPT`
 
 ##### `extractMessagesFromFile(filePath, [options])`
 
-Parses a JS(X) file for translatable strings and returns a list of message objects.
+Parses a JS(X) or Typescript file for translatable strings and returns a list of message objects.
 
 ##### `extractMessagesFromGlob(globStr, [options])`
 
-Parses JS(X) files matching a glob for translatable strings and returns a list of message objects.
+Parses JS(X) or Typescript files matching a glob for translatable strings and returns a list of message objects.
 
 ##### `parse(code, [options], [callback])`
 
 Parses a string with JS(X) source code for translatable strings and writes a .pot file containing those strings.
+When use with typescript source code, specify option `sourceType` as `TYPESCRIPT`
 
 ##### `parseFile(filePath, [options], [callback])`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,968 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/cli": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/@babel/cli/-/cli-7.0.0-beta.44.tgz",
+      "integrity": "sha512-f+Yd3uZpZse9K3s1PcfyqlKoku3u/neAUFSDXFXkEuiD7m8GwP6NiDwa77qvFvH6jNzT4gteFr0SqjYMjg5Hzg==",
+      "dev": true,
+      "requires": {
+        "chokidar": "1.7.0",
+        "commander": "2.9.0",
+        "convert-source-map": "1.5.0",
+        "fs-readdir-recursive": "1.0.0",
+        "glob": "7.1.2",
+        "lodash": "4.17.4",
+        "output-file-sync": "2.0.1",
+        "slash": "1.0.0",
+        "source-map": "0.5.6"
+      },
+      "dependencies": {
+        "output-file-sync": {
+          "version": "2.0.1",
+          "resolved": "https://npm.corp.indeed.com/repository/npm/output-file-sync/-/output-file-sync-2.0.1.tgz",
+          "integrity": "sha512-mDho4qm7WgIXIGf4eYU1RHN2UU5tPfVYVSRwDJw0uTmj35DQUt/eNp19N7v6T3SrR0ESTEf2up2CGO73qI35zQ==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "is-plain-obj": "1.1.0",
+            "mkdirp": "0.5.1"
+          }
+        }
+      }
+    },
+    "@babel/code-frame": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/@babel/code-frame/-/code-frame-7.0.0-beta.44.tgz",
+      "integrity": "sha512-cuAuTTIQ9RqcFRJ/Y8PvTh+paepNcaGxwQwjIDRWPXmzzyAeCO4KqS9ikMvq0MCbRk6GlYKwfzStrcP3/jSL8g==",
+      "requires": {
+        "@babel/highlight": "7.0.0-beta.44"
+      }
+    },
+    "@babel/core": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/@babel/core/-/core-7.0.0-beta.44.tgz",
+      "integrity": "sha512-E16ps55Av+GAO6qVTZeVR5FMVppraUPjiJEHuH0sANsbmkEjqQ70XQiv0KXPYbPzHBd+gijx6uLakSacjvtwIA==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "7.0.0-beta.44",
+        "@babel/generator": "7.0.0-beta.44",
+        "@babel/helpers": "7.0.0-beta.44",
+        "@babel/template": "7.0.0-beta.44",
+        "@babel/traverse": "7.0.0-beta.44",
+        "@babel/types": "7.0.0-beta.44",
+        "babylon": "7.0.0-beta.44",
+        "convert-source-map": "1.5.0",
+        "debug": "3.1.0",
+        "json5": "0.5.1",
+        "lodash": "4.17.4",
+        "micromatch": "2.3.11",
+        "resolve": "1.7.1",
+        "semver": "5.5.0",
+        "source-map": "0.5.6"
+      },
+      "dependencies": {
+        "babylon": {
+          "version": "7.0.0-beta.44",
+          "resolved": "https://npm.corp.indeed.com/repository/npm/babylon/-/babylon-7.0.0-beta.44.tgz",
+          "integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g==",
+          "dev": true
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://npm.corp.indeed.com/repository/npm/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "semver": {
+          "version": "5.5.0",
+          "resolved": "https://npm.corp.indeed.com/repository/npm/semver/-/semver-5.5.0.tgz",
+          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/generator": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/@babel/generator/-/generator-7.0.0-beta.44.tgz",
+      "integrity": "sha512-5xVb7hlhjGcdkKpMXgicAVgx8syK5VJz193k0i/0sLP6DzE6lRrU1K3B/rFefgdo9LPGMAOOOAWW4jycj07ShQ==",
+      "requires": {
+        "@babel/types": "7.0.0-beta.44",
+        "jsesc": "2.5.1",
+        "lodash": "4.17.4",
+        "source-map": "0.5.6",
+        "trim-right": "1.0.1"
+      },
+      "dependencies": {
+        "jsesc": {
+          "version": "2.5.1",
+          "resolved": "https://npm.corp.indeed.com/repository/npm/jsesc/-/jsesc-2.5.1.tgz",
+          "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4="
+        }
+      }
+    },
+    "@babel/helper-annotate-as-pure": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0-beta.44.tgz",
+      "integrity": "sha512-trEw653XRNMCBIno/GyuffHi7AxB4miw1EHDeA/q9uIYNdyaXahIdQuBlbzGRWWoBdObFf4Ua0cDFgWkrfgBPw==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.0.0-beta.44"
+      }
+    },
+    "@babel/helper-builder-binary-assignment-operator-visitor": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.0.0-beta.44.tgz",
+      "integrity": "sha512-M9+OPXXT3yqTvMlUmvXf53NX7qkzGkahXnkIyY15gNP/yWGG5ODYNa225Mq7/Vp0zMrI7JastEnn0AuEXSUQWA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-explode-assignable-expression": "7.0.0-beta.44",
+        "@babel/types": "7.0.0-beta.44"
+      }
+    },
+    "@babel/helper-call-delegate": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/@babel/helper-call-delegate/-/helper-call-delegate-7.0.0-beta.44.tgz",
+      "integrity": "sha512-2J9K2S2emLBqdNicB1lsjn3bIKPmn9/E5aNu5Yx8TS3pFpMRJjh4PQq5m669L+sajPw/9KE2U089xjPmPn1qcg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-hoist-variables": "7.0.0-beta.44",
+        "@babel/traverse": "7.0.0-beta.44",
+        "@babel/types": "7.0.0-beta.44"
+      }
+    },
+    "@babel/helper-define-map": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/@babel/helper-define-map/-/helper-define-map-7.0.0-beta.44.tgz",
+      "integrity": "sha512-u0YWuZFAT8tgyp5PJX2NjmU6UrKgQF2AZ0aqXXC/RMEdEFRGDe4t/VBk6MCvKjyOb8R5UqiaPJszq1VLB67aTw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "7.0.0-beta.44",
+        "@babel/types": "7.0.0-beta.44",
+        "lodash": "4.17.4"
+      }
+    },
+    "@babel/helper-explode-assignable-expression": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.0.0-beta.44.tgz",
+      "integrity": "sha512-XM+nY15w/Hyb9yKhGnMMV3R2RUdPGl8/+pTfOKBt4/eLapozSrUh+7xrMOwgJOO+TWuQMlMbQLRJUiMsHUHNbw==",
+      "dev": true,
+      "requires": {
+        "@babel/traverse": "7.0.0-beta.44",
+        "@babel/types": "7.0.0-beta.44"
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.44.tgz",
+      "integrity": "sha512-MHRG2qZMKMFaBavX0LWpfZ2e+hLloT++N7rfM3DYOMUOGCD8cVjqZpwiL8a0bOX3IYcQev1ruciT0gdFFRTxzg==",
+      "requires": {
+        "@babel/helper-get-function-arity": "7.0.0-beta.44",
+        "@babel/template": "7.0.0-beta.44",
+        "@babel/types": "7.0.0-beta.44"
+      }
+    },
+    "@babel/helper-get-function-arity": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.44.tgz",
+      "integrity": "sha512-w0YjWVwrM2HwP6/H3sEgrSQdkCaxppqFeJtAnB23pRiJB5E/O9Yp7JAAeWBl+gGEgmBFinnTyOv2RN7rcSmMiw==",
+      "requires": {
+        "@babel/types": "7.0.0-beta.44"
+      }
+    },
+    "@babel/helper-hoist-variables": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/@babel/helper-hoist-variables/-/helper-hoist-variables-7.0.0-beta.44.tgz",
+      "integrity": "sha512-WRMGJKSVP32/T7pBAb52oXa7dSGgtHk2VZ0nii/MzrXh40IYqNGRmKdI7x57pL421ccvnqZg+mgOH+mNFSKm6g==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.0.0-beta.44"
+      }
+    },
+    "@babel/helper-module-imports": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/@babel/helper-module-imports/-/helper-module-imports-7.0.0-beta.44.tgz",
+      "integrity": "sha512-V95wi6rCffcLM46XdaUJHRc3D/XSvfsQshedaX1riHQCbs0uVopdswXrykwB6E/QEPfUGxXfs7l5GubupOi+Cw==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.0.0-beta.44",
+        "lodash": "4.17.4"
+      }
+    },
+    "@babel/helper-module-transforms": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/@babel/helper-module-transforms/-/helper-module-transforms-7.0.0-beta.44.tgz",
+      "integrity": "sha512-mwoQuzm1xY3L00Rf6vHO0tFKkBxarODf1f5l4wClTzvBmm7ReikPKyNwgS7wp2dzlorpIKPAAw+n3IEhnOjLJg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "7.0.0-beta.44",
+        "@babel/helper-simple-access": "7.0.0-beta.44",
+        "@babel/helper-split-export-declaration": "7.0.0-beta.44",
+        "@babel/template": "7.0.0-beta.44",
+        "@babel/types": "7.0.0-beta.44",
+        "lodash": "4.17.4"
+      }
+    },
+    "@babel/helper-optimise-call-expression": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0-beta.44.tgz",
+      "integrity": "sha512-A9JodnSG8mNiazppInvrAtw4rN+TW61He/EnZ9szVgWkivonZeuG2D0hVLpE5sYuqw128seyw+tY9NEY7txmcQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.0.0-beta.44"
+      }
+    },
+    "@babel/helper-plugin-utils": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.44.tgz",
+      "integrity": "sha512-k0hZ8w9N3b0Psmlw0bB7U9Hwqc+/hh7yOPFyLi5KAX9pRZ9i+UbTg6DxsVLVuITvF/M1UZNrq7vatrlEw/IPMg==",
+      "dev": true
+    },
+    "@babel/helper-regex": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/@babel/helper-regex/-/helper-regex-7.0.0-beta.44.tgz",
+      "integrity": "sha512-UiL6tMd2eUPK6RVpaeUzQ0jDFzGaeQ3All+YpFc+K9onz1BXDArFoJBygZfkjOgfmwBiSbXLShpRBA5QMgOSmQ==",
+      "dev": true,
+      "requires": {
+        "lodash": "4.17.4"
+      }
+    },
+    "@babel/helper-remap-async-to-generator": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.0.0-beta.44.tgz",
+      "integrity": "sha512-Jk2mwO7QOx9n5ktVx8OOuuybyCuZ+gSnd9HqkdxqdfjF+kzJ6FvQ1QUqOf3Dg1uTFmN2/UzBpFgFV4OH71xmWw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "7.0.0-beta.44",
+        "@babel/helper-wrap-function": "7.0.0-beta.44",
+        "@babel/template": "7.0.0-beta.44",
+        "@babel/traverse": "7.0.0-beta.44",
+        "@babel/types": "7.0.0-beta.44"
+      }
+    },
+    "@babel/helper-replace-supers": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/@babel/helper-replace-supers/-/helper-replace-supers-7.0.0-beta.44.tgz",
+      "integrity": "sha512-8PTdsyYE+Fyn8Qy0Da7YnmXhm+vOI73YFHcrAW2s81g9Ae5F3ZA+RvQQe7RPP2mi+Jg/GqXGPUmHYqDpQ3pT9Q==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-optimise-call-expression": "7.0.0-beta.44",
+        "@babel/template": "7.0.0-beta.44",
+        "@babel/traverse": "7.0.0-beta.44",
+        "@babel/types": "7.0.0-beta.44"
+      }
+    },
+    "@babel/helper-simple-access": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/@babel/helper-simple-access/-/helper-simple-access-7.0.0-beta.44.tgz",
+      "integrity": "sha512-z6tIoPYPT9VOgVSKC7wPjobjvCP/DEfM0uvMDhofAl8p0GDMmMCCs46UNBr6hW1T55WgUGdkNiCFYVnCLjWNFQ==",
+      "dev": true,
+      "requires": {
+        "@babel/template": "7.0.0-beta.44",
+        "@babel/types": "7.0.0-beta.44",
+        "lodash": "4.17.4"
+      }
+    },
+    "@babel/helper-split-export-declaration": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.44.tgz",
+      "integrity": "sha512-aQ7QowtkgKKzPGf0j6u77kBMdUFVBKNHw2p/3HX/POt5/oz8ec5cs0GwlgM8Hz7ui5EwJnzyfRmkNF1Nx1N7aA==",
+      "requires": {
+        "@babel/types": "7.0.0-beta.44"
+      }
+    },
+    "@babel/helper-wrap-function": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/@babel/helper-wrap-function/-/helper-wrap-function-7.0.0-beta.44.tgz",
+      "integrity": "sha512-qCdMAdMzDhO87r7yS2adqzIl2N9FJaVkPYq6bKllkNcmHquytve+hd/jD/lruD71i3JWkH+M352U+lhW2qkToA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "7.0.0-beta.44",
+        "@babel/template": "7.0.0-beta.44",
+        "@babel/traverse": "7.0.0-beta.44",
+        "@babel/types": "7.0.0-beta.44"
+      }
+    },
+    "@babel/helpers": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/@babel/helpers/-/helpers-7.0.0-beta.44.tgz",
+      "integrity": "sha512-7qXsqiaMZzVuI0dobFGa9dQhCd6Y19lGeu4HrFHJo13/y9NKngepg/CYMzBi79TacKeaWfJNj3TeVCyRtfZqUg==",
+      "dev": true,
+      "requires": {
+        "@babel/template": "7.0.0-beta.44",
+        "@babel/traverse": "7.0.0-beta.44",
+        "@babel/types": "7.0.0-beta.44"
+      }
+    },
+    "@babel/highlight": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/@babel/highlight/-/highlight-7.0.0-beta.44.tgz",
+      "integrity": "sha512-Il19yJvy7vMFm8AVAh6OZzaFoAd0hbkeMZiX3P5HGD+z7dyI7RzndHB0dg6Urh/VAFfHtpOIzDUSxmY6coyZWQ==",
+      "requires": {
+        "chalk": "2.4.0",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://npm.corp.indeed.com/repository/npm/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.4.0",
+          "resolved": "https://npm.corp.indeed.com/repository/npm/chalk/-/chalk-2.4.0.tgz",
+          "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://npm.corp.indeed.com/repository/npm/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
+      }
+    },
+    "@babel/plugin-proposal-async-generator-functions": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.0.0-beta.44.tgz",
+      "integrity": "sha512-FW6MZpaFERkozQ5eS3PG/645nubF+d6JjgcyBGlhB98qKd9NmdRLHZJ0eKmpA6yG8TeDzpsUve0BE/+XNAYLrw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.44",
+        "@babel/helper-remap-async-to-generator": "7.0.0-beta.44",
+        "@babel/plugin-syntax-async-generators": "7.0.0-beta.44"
+      }
+    },
+    "@babel/plugin-proposal-object-rest-spread": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0-beta.44.tgz",
+      "integrity": "sha512-56Pqyeq3weYZccmcyzS4DVyVQ11SGWS6xCj/a5SmhvKXGHC2pEVovIBF63dFoQTlYFOzix9sZyW5oNVWicbTRg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.44",
+        "@babel/plugin-syntax-object-rest-spread": "7.0.0-beta.44"
+      }
+    },
+    "@babel/plugin-proposal-optional-catch-binding": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.0.0-beta.44.tgz",
+      "integrity": "sha512-yAsZXzirCSUU1Bts1gpd5YJrE8cNHsvpU0umPFkd+zXNV9X1DuOKlbiBcZXoVoyoRcMs7BP15L+/IQ5HSVHQPg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.44",
+        "@babel/plugin-syntax-optional-catch-binding": "7.0.0-beta.44"
+      }
+    },
+    "@babel/plugin-proposal-unicode-property-regex": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.0.0-beta.44.tgz",
+      "integrity": "sha512-K0eTqDoUfJT7UKnw9/looJEd8XB0WyOp7uIRHCdbewEjuL1OSza2unxJFoa8BfMAykou7M+L3wJ3O3C+hjjOtQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.44",
+        "@babel/helper-regex": "7.0.0-beta.44",
+        "regexpu-core": "4.1.3"
+      },
+      "dependencies": {
+        "jsesc": {
+          "version": "0.5.0",
+          "resolved": "https://npm.corp.indeed.com/repository/npm/jsesc/-/jsesc-0.5.0.tgz",
+          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+          "dev": true
+        },
+        "regenerate": {
+          "version": "1.3.3",
+          "resolved": "https://npm.corp.indeed.com/repository/npm/regenerate/-/regenerate-1.3.3.tgz",
+          "integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg==",
+          "dev": true
+        },
+        "regexpu-core": {
+          "version": "4.1.3",
+          "resolved": "https://npm.corp.indeed.com/repository/npm/regexpu-core/-/regexpu-core-4.1.3.tgz",
+          "integrity": "sha512-mB+njEzO7oezA57IbQxxd6fVPOeWKDmnGvJ485CwmfNchjHe5jWwqKepapmzUEj41yxIAqOg+C4LbXuJlkiO8A==",
+          "dev": true,
+          "requires": {
+            "regenerate": "1.3.3",
+            "regenerate-unicode-properties": "5.1.3",
+            "regjsgen": "0.3.0",
+            "regjsparser": "0.2.1",
+            "unicode-match-property-ecmascript": "1.0.3",
+            "unicode-match-property-value-ecmascript": "1.0.1"
+          }
+        },
+        "regjsgen": {
+          "version": "0.3.0",
+          "resolved": "https://npm.corp.indeed.com/repository/npm/regjsgen/-/regjsgen-0.3.0.tgz",
+          "integrity": "sha1-DuSj6SdkMM2iXx54nqbBW4ewy0M=",
+          "dev": true
+        },
+        "regjsparser": {
+          "version": "0.2.1",
+          "resolved": "https://npm.corp.indeed.com/repository/npm/regjsparser/-/regjsparser-0.2.1.tgz",
+          "integrity": "sha1-w3h1U/rwTndcMCEC7zRtmVAA7Bw=",
+          "dev": true,
+          "requires": {
+            "jsesc": "0.5.0"
+          }
+        }
+      }
+    },
+    "@babel/plugin-syntax-async-generators": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.0.0-beta.44.tgz",
+      "integrity": "sha512-42MXWQvAN2IPPcW4HUbqgeyqkAwAsCGIHzxgSYoI7aOgkfOwHf5LRqSlJ56HAH+WwlWDQUvXeT/2PrQQY1vSCw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.44"
+      }
+    },
+    "@babel/plugin-syntax-object-rest-spread": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.0.0-beta.44.tgz",
+      "integrity": "sha512-pVk9nFH7AAmn9Zor8Rv6g/JVXFwBW4FSFV1/3W84bw9s8yc8LZ7KqrCCpcHgBACVWJYnAtoxsaf7FFcQFl/z7Q==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.44"
+      }
+    },
+    "@babel/plugin-syntax-optional-catch-binding": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.0.0-beta.44.tgz",
+      "integrity": "sha512-JnkSHFn+F3KHhFXRtc5qdkvOcFVOZR4NqIdgoNp87pNrLksmcHRwPtbJPuL2vSyUlr1Fd0QuAt6CDNpgf+55Mw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.44"
+      }
+    },
+    "@babel/plugin-transform-arrow-functions": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.0.0-beta.44.tgz",
+      "integrity": "sha512-EnE9WACf+ZQZcLcmT26PEaIs3aWhr6shLJIdhaqZavN3CitxJvfia1q8WyCS4GO3wIdopgdeIpD2Xwe4wmJFFQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.44"
+      }
+    },
+    "@babel/plugin-transform-async-to-generator": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.0.0-beta.44.tgz",
+      "integrity": "sha512-+LTuKGnAd8w7FV45N+CvNE77GdcVMDT/w7so9++3jbG28w5id6VtQZ9cpFbqdvkZlpTy68Saw9zZcQeRZV3bmg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "7.0.0-beta.44",
+        "@babel/helper-plugin-utils": "7.0.0-beta.44",
+        "@babel/helper-remap-async-to-generator": "7.0.0-beta.44"
+      }
+    },
+    "@babel/plugin-transform-block-scoped-functions": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.0.0-beta.44.tgz",
+      "integrity": "sha512-taD9vmzEyG4a5wZadYFVGnCgPU3JlkPrOMCmrIgqKT+AWuxwavSbtPJnUh2NfJDpvx005s/OIncc/3fpTx502Q==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.44"
+      }
+    },
+    "@babel/plugin-transform-block-scoping": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.0.0-beta.44.tgz",
+      "integrity": "sha512-a9mt8PwVaudo8LbLrp7TpbwV/HoO7T9Wjyr/aHB4UisUfQoE89iWBJYIweL/ho831Nzy8mNJlXfNxAfZc7Fojw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.44",
+        "lodash": "4.17.4"
+      }
+    },
+    "@babel/plugin-transform-classes": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/@babel/plugin-transform-classes/-/plugin-transform-classes-7.0.0-beta.44.tgz",
+      "integrity": "sha512-oQE40NQ9HBg3KJppRrG0AFYmb73mVJUPmFjUZtuMlFJWV4kAyPwfGC98MDJ7fFjGZLIWesJD7yE+eh0e4N2ssQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "7.0.0-beta.44",
+        "@babel/helper-define-map": "7.0.0-beta.44",
+        "@babel/helper-function-name": "7.0.0-beta.44",
+        "@babel/helper-optimise-call-expression": "7.0.0-beta.44",
+        "@babel/helper-plugin-utils": "7.0.0-beta.44",
+        "@babel/helper-replace-supers": "7.0.0-beta.44",
+        "@babel/helper-split-export-declaration": "7.0.0-beta.44",
+        "globals": "11.4.0"
+      },
+      "dependencies": {
+        "globals": {
+          "version": "11.4.0",
+          "resolved": "https://npm.corp.indeed.com/repository/npm/globals/-/globals-11.4.0.tgz",
+          "integrity": "sha512-Dyzmifil8n/TmSqYDEXbm+C8yitzJQqQIlJQLNRMwa+BOUJpRC19pyVeN12JAjt61xonvXjtff+hJruTRXn5HA==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/plugin-transform-computed-properties": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.0.0-beta.44.tgz",
+      "integrity": "sha512-gLzREw6hb6qDoJMx/uMcXfkom5mboBi7yWg0S/uyof4laIl7cPCrrCleYZfi4sF9CgRPP48TMIoi2rVtKvrJ1g==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.44"
+      }
+    },
+    "@babel/plugin-transform-destructuring": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.0.0-beta.44.tgz",
+      "integrity": "sha512-lTWaW8O3V01efNRDcAyf9iZ/kVuZc2PNHoCYitm74H/LVBk3dkKb4TymMDq/xYcTQCNPw5EvEH+3NIiLL29/Mw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.44"
+      }
+    },
+    "@babel/plugin-transform-dotall-regex": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.0.0-beta.44.tgz",
+      "integrity": "sha512-4oF4gIPOUbljRGzdMdTAKVojOurkoMh3QLsGTPgNp1HrGtIKAQMprojA9O6gXwseIqiaVSnx3RwaVo3nHzS0oA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.44",
+        "@babel/helper-regex": "7.0.0-beta.44",
+        "regexpu-core": "4.1.3"
+      },
+      "dependencies": {
+        "jsesc": {
+          "version": "0.5.0",
+          "resolved": "https://npm.corp.indeed.com/repository/npm/jsesc/-/jsesc-0.5.0.tgz",
+          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+          "dev": true
+        },
+        "regenerate": {
+          "version": "1.3.3",
+          "resolved": "https://npm.corp.indeed.com/repository/npm/regenerate/-/regenerate-1.3.3.tgz",
+          "integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg==",
+          "dev": true
+        },
+        "regexpu-core": {
+          "version": "4.1.3",
+          "resolved": "https://npm.corp.indeed.com/repository/npm/regexpu-core/-/regexpu-core-4.1.3.tgz",
+          "integrity": "sha512-mB+njEzO7oezA57IbQxxd6fVPOeWKDmnGvJ485CwmfNchjHe5jWwqKepapmzUEj41yxIAqOg+C4LbXuJlkiO8A==",
+          "dev": true,
+          "requires": {
+            "regenerate": "1.3.3",
+            "regenerate-unicode-properties": "5.1.3",
+            "regjsgen": "0.3.0",
+            "regjsparser": "0.2.1",
+            "unicode-match-property-ecmascript": "1.0.3",
+            "unicode-match-property-value-ecmascript": "1.0.1"
+          }
+        },
+        "regjsgen": {
+          "version": "0.3.0",
+          "resolved": "https://npm.corp.indeed.com/repository/npm/regjsgen/-/regjsgen-0.3.0.tgz",
+          "integrity": "sha1-DuSj6SdkMM2iXx54nqbBW4ewy0M=",
+          "dev": true
+        },
+        "regjsparser": {
+          "version": "0.2.1",
+          "resolved": "https://npm.corp.indeed.com/repository/npm/regjsparser/-/regjsparser-0.2.1.tgz",
+          "integrity": "sha1-w3h1U/rwTndcMCEC7zRtmVAA7Bw=",
+          "dev": true,
+          "requires": {
+            "jsesc": "0.5.0"
+          }
+        }
+      }
+    },
+    "@babel/plugin-transform-duplicate-keys": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.0.0-beta.44.tgz",
+      "integrity": "sha512-j0qCx+zKF/iZXJBGm9QRJ9VCQuiFdZJHTueGPuzb2oxNMj2hPv+Uf2SOidxglbvHaGmDoODs6M0dVXnHTGoy9g==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.44"
+      }
+    },
+    "@babel/plugin-transform-exponentiation-operator": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.0.0-beta.44.tgz",
+      "integrity": "sha512-6muSWR3UxdAnVnk8a4rxESNQk7F+djM+oeKkETMgWbw6TyaNaTD7OYkKGTdyTT5jn2UO97sPdgOBIBdnzQsKQg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-builder-binary-assignment-operator-visitor": "7.0.0-beta.44",
+        "@babel/helper-plugin-utils": "7.0.0-beta.44"
+      }
+    },
+    "@babel/plugin-transform-for-of": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.0.0-beta.44.tgz",
+      "integrity": "sha512-910UuvEuN6CM3G7+V3fHnYFBbw/YZUGgQlXpdlQnzN43uny2Xy33BxoFlWq1dOS1Q7xJnsJNEb2mm2Eks2uTvg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.44"
+      }
+    },
+    "@babel/plugin-transform-function-name": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.0.0-beta.44.tgz",
+      "integrity": "sha512-GDxrbHs4VsbJjZbozMZY7AfMqGZ4U0LNp2YpZ6rMi++1LOo/pmSZ95VSX2T/XfI1c7xNVuVQDbH0QjaJUzUepw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "7.0.0-beta.44",
+        "@babel/helper-plugin-utils": "7.0.0-beta.44"
+      }
+    },
+    "@babel/plugin-transform-literals": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/@babel/plugin-transform-literals/-/plugin-transform-literals-7.0.0-beta.44.tgz",
+      "integrity": "sha512-h6KxHCj14tYj1dahXlfs/JP1fMzMHdmVCapM4UjberhkcAj4ZkZpmdQbN2odaQRT1DX2hA8eQWsmeKJw2Ifq8w==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.44"
+      }
+    },
+    "@babel/plugin-transform-modules-amd": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.0.0-beta.44.tgz",
+      "integrity": "sha512-dVaGOhwv8VogqXOtIKoFczjCadSf6PMEafgumE+3tOmzIrM1gFplC7rDxi52RKSOxrl8q07Lc1PToh4k/7+nRA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-transforms": "7.0.0-beta.44",
+        "@babel/helper-plugin-utils": "7.0.0-beta.44"
+      }
+    },
+    "@babel/plugin-transform-modules-commonjs": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.0.0-beta.44.tgz",
+      "integrity": "sha512-wi1CPE/1G+EhJwFMgF0zhtE427dspqakhkl4na0KW0xmzh1Q3EKhfHsK/gizzNQlNtHRaW/Ks/vafJD3bAlk1Q==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-transforms": "7.0.0-beta.44",
+        "@babel/helper-plugin-utils": "7.0.0-beta.44",
+        "@babel/helper-simple-access": "7.0.0-beta.44"
+      }
+    },
+    "@babel/plugin-transform-modules-systemjs": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.0.0-beta.44.tgz",
+      "integrity": "sha512-sFY/F3a5WzscOsHqcEyKLxySZzpQLuz98ZBwzDOplpY7BlkJGWNLwwh98Z/F+EddvHJ54Q9WgSw/PMC9LUKXSQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-hoist-variables": "7.0.0-beta.44",
+        "@babel/helper-plugin-utils": "7.0.0-beta.44"
+      }
+    },
+    "@babel/plugin-transform-modules-umd": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.0.0-beta.44.tgz",
+      "integrity": "sha512-thm2inPP4aSdYRUauR2gVC3s0g5UGK1kUns7DBpZQBSY9eJjAr5LqmXhQh1Szq79vI1ZRZTDoxrTkdFqubAALA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-transforms": "7.0.0-beta.44",
+        "@babel/helper-plugin-utils": "7.0.0-beta.44"
+      }
+    },
+    "@babel/plugin-transform-new-target": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.0.0-beta.44.tgz",
+      "integrity": "sha512-clkSQygTIEDo4GCKBI4FXvbqBTz9Mnp6gLLlYodxua2sVEAym877k5ndvoBjXT6Gvymq1YoO4Eeot8x7rXNPFA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.44"
+      }
+    },
+    "@babel/plugin-transform-object-super": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.0.0-beta.44.tgz",
+      "integrity": "sha512-KlcV7gSBppnANHxCk8Hxca2PCrKOAoSTWj7HxiGCwrOcRJeMYPIiBayExGmfN7Ymvt0EpgSvL8bwyOPMk10mgg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.44",
+        "@babel/helper-replace-supers": "7.0.0-beta.44"
+      }
+    },
+    "@babel/plugin-transform-parameters": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.0.0-beta.44.tgz",
+      "integrity": "sha512-TDEBU2tSAKC0HESeVPwVY6Wlcwgpml5ZymSqxqY0Gr7ei7PTON2O7zmntfmyiigN3BoHxuXnqFqwaz//3KxtTA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-call-delegate": "7.0.0-beta.44",
+        "@babel/helper-get-function-arity": "7.0.0-beta.44",
+        "@babel/helper-plugin-utils": "7.0.0-beta.44"
+      }
+    },
+    "@babel/plugin-transform-regenerator": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.0.0-beta.44.tgz",
+      "integrity": "sha512-G2M4SqLMVJK5y3fs0qgGaBscUmEhAXEY25qNtPBgYsGmdl8k0sdBAf2/4s97iLmhU234DqJYSGa4VS38sau0ig==",
+      "dev": true,
+      "requires": {
+        "regenerator-transform": "0.12.3"
+      },
+      "dependencies": {
+        "regenerator-transform": {
+          "version": "0.12.3",
+          "resolved": "https://npm.corp.indeed.com/repository/npm/regenerator-transform/-/regenerator-transform-0.12.3.tgz",
+          "integrity": "sha512-y2uxO/6u+tVmtEDIKo+tLCtI0GcbQr0OreosKgCd7HP4VypGjtTrw79DezuwT+W5QX0YWuvpeBOgumrepwM1kA==",
+          "dev": true,
+          "requires": {
+            "private": "0.1.7"
+          }
+        }
+      }
+    },
+    "@babel/plugin-transform-shorthand-properties": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.0.0-beta.44.tgz",
+      "integrity": "sha512-LG213xsGpvCB09Tq7EMaO3COzyNhzV7Hss00UMXR3AId4EThwRoYiLKnekqoOasNdocN+09fKyH3cf/llJgZhQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.44"
+      }
+    },
+    "@babel/plugin-transform-spread": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/@babel/plugin-transform-spread/-/plugin-transform-spread-7.0.0-beta.44.tgz",
+      "integrity": "sha512-8fEte+nRW4OSdC23P0KBpiE7U4j0GpupMchnsjySYYNimKFnzPP5UYacZ6Lti5kS0XAnVfs09iHLXG1ccsWQsA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.44"
+      }
+    },
+    "@babel/plugin-transform-sticky-regex": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.0.0-beta.44.tgz",
+      "integrity": "sha512-iqByRYvEMG59aOsAAJKRuolqwQOrRIGDfLTaDr45uaW5OLKUaQiPG/BxMF0WDNcQhKIhxiLUZ2K1s26v6SpsKg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.44",
+        "@babel/helper-regex": "7.0.0-beta.44"
+      }
+    },
+    "@babel/plugin-transform-template-literals": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.0.0-beta.44.tgz",
+      "integrity": "sha512-HePlWdKQ5iMTq5C5Zs8hfI0ro2grH+varpTSLpUCOhnYl3yL9bbbgPAdbUwICasi+lIT0Gt94c73BZ1bCnfTWw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "7.0.0-beta.44",
+        "@babel/helper-plugin-utils": "7.0.0-beta.44"
+      }
+    },
+    "@babel/plugin-transform-typeof-symbol": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.0.0-beta.44.tgz",
+      "integrity": "sha512-ObXHYNMRrvRcKANNVbR50ZrtX5i7qiJYH2GiD4snt6pOEooWJQmbHALFyTS/+I4eCVhNe6CQ6cMqXDhMl0RYOw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.44"
+      }
+    },
+    "@babel/plugin-transform-unicode-regex": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.0.0-beta.44.tgz",
+      "integrity": "sha512-AD5T8aBMcS+dCyaF2WTT2zVPW86+ISxFCKZp6/Nh98SFxaXKuGtT1POvL7eoj3p18JN3mixAImmJSA7ppCDbJQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.44",
+        "@babel/helper-regex": "7.0.0-beta.44",
+        "regexpu-core": "4.1.3"
+      },
+      "dependencies": {
+        "jsesc": {
+          "version": "0.5.0",
+          "resolved": "https://npm.corp.indeed.com/repository/npm/jsesc/-/jsesc-0.5.0.tgz",
+          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+          "dev": true
+        },
+        "regenerate": {
+          "version": "1.3.3",
+          "resolved": "https://npm.corp.indeed.com/repository/npm/regenerate/-/regenerate-1.3.3.tgz",
+          "integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg==",
+          "dev": true
+        },
+        "regexpu-core": {
+          "version": "4.1.3",
+          "resolved": "https://npm.corp.indeed.com/repository/npm/regexpu-core/-/regexpu-core-4.1.3.tgz",
+          "integrity": "sha512-mB+njEzO7oezA57IbQxxd6fVPOeWKDmnGvJ485CwmfNchjHe5jWwqKepapmzUEj41yxIAqOg+C4LbXuJlkiO8A==",
+          "dev": true,
+          "requires": {
+            "regenerate": "1.3.3",
+            "regenerate-unicode-properties": "5.1.3",
+            "regjsgen": "0.3.0",
+            "regjsparser": "0.2.1",
+            "unicode-match-property-ecmascript": "1.0.3",
+            "unicode-match-property-value-ecmascript": "1.0.1"
+          }
+        },
+        "regjsgen": {
+          "version": "0.3.0",
+          "resolved": "https://npm.corp.indeed.com/repository/npm/regjsgen/-/regjsgen-0.3.0.tgz",
+          "integrity": "sha1-DuSj6SdkMM2iXx54nqbBW4ewy0M=",
+          "dev": true
+        },
+        "regjsparser": {
+          "version": "0.2.1",
+          "resolved": "https://npm.corp.indeed.com/repository/npm/regjsparser/-/regjsparser-0.2.1.tgz",
+          "integrity": "sha1-w3h1U/rwTndcMCEC7zRtmVAA7Bw=",
+          "dev": true,
+          "requires": {
+            "jsesc": "0.5.0"
+          }
+        }
+      }
+    },
+    "@babel/preset-env": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/@babel/preset-env/-/preset-env-7.0.0-beta.44.tgz",
+      "integrity": "sha512-b0fiva7rflvUH1+PcehxE8820GdcaMUxyIhL3zhgs/CQour8cJgI6voR6b3lEP5l6wOglPvKyW9dFSSOPknaBA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "7.0.0-beta.44",
+        "@babel/helper-plugin-utils": "7.0.0-beta.44",
+        "@babel/plugin-proposal-async-generator-functions": "7.0.0-beta.44",
+        "@babel/plugin-proposal-object-rest-spread": "7.0.0-beta.44",
+        "@babel/plugin-proposal-optional-catch-binding": "7.0.0-beta.44",
+        "@babel/plugin-proposal-unicode-property-regex": "7.0.0-beta.44",
+        "@babel/plugin-syntax-async-generators": "7.0.0-beta.44",
+        "@babel/plugin-syntax-object-rest-spread": "7.0.0-beta.44",
+        "@babel/plugin-syntax-optional-catch-binding": "7.0.0-beta.44",
+        "@babel/plugin-transform-arrow-functions": "7.0.0-beta.44",
+        "@babel/plugin-transform-async-to-generator": "7.0.0-beta.44",
+        "@babel/plugin-transform-block-scoped-functions": "7.0.0-beta.44",
+        "@babel/plugin-transform-block-scoping": "7.0.0-beta.44",
+        "@babel/plugin-transform-classes": "7.0.0-beta.44",
+        "@babel/plugin-transform-computed-properties": "7.0.0-beta.44",
+        "@babel/plugin-transform-destructuring": "7.0.0-beta.44",
+        "@babel/plugin-transform-dotall-regex": "7.0.0-beta.44",
+        "@babel/plugin-transform-duplicate-keys": "7.0.0-beta.44",
+        "@babel/plugin-transform-exponentiation-operator": "7.0.0-beta.44",
+        "@babel/plugin-transform-for-of": "7.0.0-beta.44",
+        "@babel/plugin-transform-function-name": "7.0.0-beta.44",
+        "@babel/plugin-transform-literals": "7.0.0-beta.44",
+        "@babel/plugin-transform-modules-amd": "7.0.0-beta.44",
+        "@babel/plugin-transform-modules-commonjs": "7.0.0-beta.44",
+        "@babel/plugin-transform-modules-systemjs": "7.0.0-beta.44",
+        "@babel/plugin-transform-modules-umd": "7.0.0-beta.44",
+        "@babel/plugin-transform-new-target": "7.0.0-beta.44",
+        "@babel/plugin-transform-object-super": "7.0.0-beta.44",
+        "@babel/plugin-transform-parameters": "7.0.0-beta.44",
+        "@babel/plugin-transform-regenerator": "7.0.0-beta.44",
+        "@babel/plugin-transform-shorthand-properties": "7.0.0-beta.44",
+        "@babel/plugin-transform-spread": "7.0.0-beta.44",
+        "@babel/plugin-transform-sticky-regex": "7.0.0-beta.44",
+        "@babel/plugin-transform-template-literals": "7.0.0-beta.44",
+        "@babel/plugin-transform-typeof-symbol": "7.0.0-beta.44",
+        "@babel/plugin-transform-unicode-regex": "7.0.0-beta.44",
+        "browserslist": "3.2.5",
+        "invariant": "2.2.2",
+        "semver": "5.3.0"
+      }
+    },
+    "@babel/register": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/@babel/register/-/register-7.0.0-beta.44.tgz",
+      "integrity": "sha512-7DlnSyWKnBE+MS+mFPsp5T+2+vz9d5GUDwIJtyCdKGeYkme6uakFVH7qpp4eMpYc47wTANoVbCEDugRQXUeTzg==",
+      "dev": true,
+      "requires": {
+        "core-js": "2.5.5",
+        "find-cache-dir": "1.0.0",
+        "home-or-tmp": "3.0.0",
+        "lodash": "4.17.4",
+        "mkdirp": "0.5.1",
+        "pirates": "3.0.2",
+        "source-map-support": "0.4.18"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.5.5",
+          "resolved": "https://npm.corp.indeed.com/repository/npm/core-js/-/core-js-2.5.5.tgz",
+          "integrity": "sha1-sU3ek2xkDAV5prUMq8wTLdYSfjs=",
+          "dev": true
+        }
+      }
+    },
+    "@babel/template": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/@babel/template/-/template-7.0.0-beta.44.tgz",
+      "integrity": "sha512-w750Sloq0UNifLx1rUqwfbnC6uSUk0mfwwgGRfdLiaUzfAOiH0tHJE6ILQIUi3KYkjiCDTskoIsnfqZvWLBDng==",
+      "requires": {
+        "@babel/code-frame": "7.0.0-beta.44",
+        "@babel/types": "7.0.0-beta.44",
+        "babylon": "7.0.0-beta.44",
+        "lodash": "4.17.4"
+      },
+      "dependencies": {
+        "babylon": {
+          "version": "7.0.0-beta.44",
+          "resolved": "https://npm.corp.indeed.com/repository/npm/babylon/-/babylon-7.0.0-beta.44.tgz",
+          "integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g=="
+        }
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/@babel/traverse/-/traverse-7.0.0-beta.44.tgz",
+      "integrity": "sha512-UHuDz8ukQkJCDASKHf+oDt3FVUzFd+QYfuBIsiNu/4+/ix6pP/C+uQZJ6K1oEfbCMv/IKWbgDEh7fcsnIE5AtA==",
+      "requires": {
+        "@babel/code-frame": "7.0.0-beta.44",
+        "@babel/generator": "7.0.0-beta.44",
+        "@babel/helper-function-name": "7.0.0-beta.44",
+        "@babel/helper-split-export-declaration": "7.0.0-beta.44",
+        "@babel/types": "7.0.0-beta.44",
+        "babylon": "7.0.0-beta.44",
+        "debug": "3.1.0",
+        "globals": "11.4.0",
+        "invariant": "2.2.2",
+        "lodash": "4.17.4"
+      },
+      "dependencies": {
+        "babylon": {
+          "version": "7.0.0-beta.44",
+          "resolved": "https://npm.corp.indeed.com/repository/npm/babylon/-/babylon-7.0.0-beta.44.tgz",
+          "integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g=="
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://npm.corp.indeed.com/repository/npm/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "globals": {
+          "version": "11.4.0",
+          "resolved": "https://npm.corp.indeed.com/repository/npm/globals/-/globals-11.4.0.tgz",
+          "integrity": "sha512-Dyzmifil8n/TmSqYDEXbm+C8yitzJQqQIlJQLNRMwa+BOUJpRC19pyVeN12JAjt61xonvXjtff+hJruTRXn5HA=="
+        }
+      }
+    },
+    "@babel/types": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/@babel/types/-/types-7.0.0-beta.44.tgz",
+      "integrity": "sha512-5eTV4WRmqbaFM3v9gHAIljEQJU4Ssc6fxL61JN+Oe2ga/BwyjzjamwkCVVAQjHGuAX8i0BWo42dshL8eO5KfLQ==",
+      "requires": {
+        "esutils": "2.0.2",
+        "lodash": "4.17.4",
+        "to-fast-properties": "2.0.0"
+      },
+      "dependencies": {
+        "to-fast-properties": {
+          "version": "2.0.0",
+          "resolved": "https://npm.corp.indeed.com/repository/npm/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+        }
+      }
+    },
     "acorn": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.0.3.tgz",
@@ -84,7 +1046,6 @@
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
       "dev": true,
-      "optional": true,
       "requires": {
         "arr-flatten": "1.0.3"
       }
@@ -93,8 +1054,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.3.tgz",
       "integrity": "sha1-onTthawIhJtr14R8RYB0XcUa37E=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "array-differ": {
       "version": "1.0.0",
@@ -119,8 +1079,7 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
       "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "arrify": {
       "version": "1.0.1",
@@ -141,64 +1100,15 @@
       "dev": true,
       "optional": true
     },
-    "babel-cli": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-cli/-/babel-cli-6.24.1.tgz",
-      "integrity": "sha1-IHzXBbumFImy6kG1MSNBz2rKIoM=",
-      "dev": true,
-      "requires": {
-        "babel-core": "6.25.0",
-        "babel-polyfill": "6.23.0",
-        "babel-register": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "chokidar": "1.7.0",
-        "commander": "2.9.0",
-        "convert-source-map": "1.5.0",
-        "fs-readdir-recursive": "1.0.0",
-        "glob": "7.1.2",
-        "lodash": "4.17.4",
-        "output-file-sync": "1.1.2",
-        "path-is-absolute": "1.0.1",
-        "slash": "1.0.0",
-        "source-map": "0.5.6",
-        "v8flags": "2.1.1"
-      }
-    },
     "babel-code-frame": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
       "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
+      "dev": true,
       "requires": {
         "chalk": "1.1.3",
         "esutils": "2.0.2",
         "js-tokens": "3.0.1"
-      }
-    },
-    "babel-core": {
-      "version": "6.25.0",
-      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.25.0.tgz",
-      "integrity": "sha1-fdQrBGPHQunVKW3rPsZ6kyLa1yk=",
-      "dev": true,
-      "requires": {
-        "babel-code-frame": "6.22.0",
-        "babel-generator": "6.25.0",
-        "babel-helpers": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-register": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "babel-template": "6.25.0",
-        "babel-traverse": "6.25.0",
-        "babel-types": "6.25.0",
-        "babylon": "6.17.4",
-        "convert-source-map": "1.5.0",
-        "debug": "2.6.8",
-        "json5": "0.5.1",
-        "lodash": "4.17.4",
-        "minimatch": "3.0.4",
-        "path-is-absolute": "1.0.1",
-        "private": "0.1.7",
-        "slash": "1.0.0",
-        "source-map": "0.5.6"
       }
     },
     "babel-eslint": {
@@ -209,515 +1119,68 @@
       "requires": {
         "babel-traverse": "6.25.0",
         "babel-types": "6.25.0",
-        "babylon": "6.17.4",
+        "babylon": "6.18.0",
         "lodash.assign": "4.2.0",
         "lodash.pickby": "4.6.0"
-      }
-    },
-    "babel-generator": {
-      "version": "6.25.0",
-      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.25.0.tgz",
-      "integrity": "sha1-M6GvcNXyiQrrRlpKd5PB32qeqfw=",
-      "dev": true,
-      "requires": {
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.25.0",
-        "detect-indent": "4.0.0",
-        "jsesc": "1.3.0",
-        "lodash": "4.17.4",
-        "source-map": "0.5.6",
-        "trim-right": "1.0.1"
-      }
-    },
-    "babel-helper-call-delegate": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
-      "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
-      "dev": true,
-      "requires": {
-        "babel-helper-hoist-variables": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "babel-traverse": "6.25.0",
-        "babel-types": "6.25.0"
-      }
-    },
-    "babel-helper-define-map": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.24.1.tgz",
-      "integrity": "sha1-epdH8ljYlH0y1RX2qhx70CIEoIA=",
-      "dev": true,
-      "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.25.0",
-        "lodash": "4.17.4"
-      }
-    },
-    "babel-helper-function-name": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
-      "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
-      "dev": true,
-      "requires": {
-        "babel-helper-get-function-arity": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "babel-template": "6.25.0",
-        "babel-traverse": "6.25.0",
-        "babel-types": "6.25.0"
-      }
-    },
-    "babel-helper-get-function-arity": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
-      "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.25.0"
-      }
-    },
-    "babel-helper-hoist-variables": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
-      "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.25.0"
-      }
-    },
-    "babel-helper-optimise-call-expression": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
-      "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.25.0"
-      }
-    },
-    "babel-helper-regex": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.24.1.tgz",
-      "integrity": "sha1-024i+rEAjXnYhkjjIRaGgShFbOg=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.25.0",
-        "lodash": "4.17.4"
-      }
-    },
-    "babel-helper-replace-supers": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
-      "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
-      "dev": true,
-      "requires": {
-        "babel-helper-optimise-call-expression": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.23.0",
-        "babel-template": "6.25.0",
-        "babel-traverse": "6.25.0",
-        "babel-types": "6.25.0"
-      }
-    },
-    "babel-helpers": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
-      "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "babel-template": "6.25.0"
+      },
+      "dependencies": {
+        "babylon": {
+          "version": "6.18.0",
+          "resolved": "https://npm.corp.indeed.com/repository/npm/babylon/-/babylon-6.18.0.tgz",
+          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+          "dev": true
+        }
       }
     },
     "babel-messages": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-      "requires": {
-        "babel-runtime": "6.23.0"
-      }
-    },
-    "babel-plugin-check-es2015-constants": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
-      "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
       "dev": true,
       "requires": {
         "babel-runtime": "6.23.0"
-      }
-    },
-    "babel-plugin-syntax-object-rest-spread": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
-      "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
-      "dev": true
-    },
-    "babel-plugin-transform-es2015-arrow-functions": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
-      "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.23.0"
-      }
-    },
-    "babel-plugin-transform-es2015-block-scoped-functions": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
-      "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.23.0"
-      }
-    },
-    "babel-plugin-transform-es2015-block-scoping": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.24.1.tgz",
-      "integrity": "sha1-dsKV3DpHQbFmWt/TFnIV3P8ypXY=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "babel-template": "6.25.0",
-        "babel-traverse": "6.25.0",
-        "babel-types": "6.25.0",
-        "lodash": "4.17.4"
-      }
-    },
-    "babel-plugin-transform-es2015-classes": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
-      "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
-      "dev": true,
-      "requires": {
-        "babel-helper-define-map": "6.24.1",
-        "babel-helper-function-name": "6.24.1",
-        "babel-helper-optimise-call-expression": "6.24.1",
-        "babel-helper-replace-supers": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.23.0",
-        "babel-template": "6.25.0",
-        "babel-traverse": "6.25.0",
-        "babel-types": "6.25.0"
-      }
-    },
-    "babel-plugin-transform-es2015-computed-properties": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
-      "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "babel-template": "6.25.0"
-      }
-    },
-    "babel-plugin-transform-es2015-destructuring": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
-      "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.23.0"
-      }
-    },
-    "babel-plugin-transform-es2015-duplicate-keys": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
-      "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.25.0"
-      }
-    },
-    "babel-plugin-transform-es2015-for-of": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
-      "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.23.0"
-      }
-    },
-    "babel-plugin-transform-es2015-function-name": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
-      "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
-      "dev": true,
-      "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.25.0"
-      }
-    },
-    "babel-plugin-transform-es2015-literals": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
-      "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.23.0"
-      }
-    },
-    "babel-plugin-transform-es2015-modules-amd": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
-      "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-transform-es2015-modules-commonjs": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "babel-template": "6.25.0"
-      }
-    },
-    "babel-plugin-transform-es2015-modules-commonjs": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.1.tgz",
-      "integrity": "sha1-0+MQtA72ZKNmIiAAl8bUQCmPK/4=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-transform-strict-mode": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "babel-template": "6.25.0",
-        "babel-types": "6.25.0"
-      }
-    },
-    "babel-plugin-transform-es2015-modules-systemjs": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
-      "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
-      "dev": true,
-      "requires": {
-        "babel-helper-hoist-variables": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "babel-template": "6.25.0"
-      }
-    },
-    "babel-plugin-transform-es2015-modules-umd": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
-      "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "babel-template": "6.25.0"
-      }
-    },
-    "babel-plugin-transform-es2015-object-super": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
-      "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
-      "dev": true,
-      "requires": {
-        "babel-helper-replace-supers": "6.24.1",
-        "babel-runtime": "6.23.0"
-      }
-    },
-    "babel-plugin-transform-es2015-parameters": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
-      "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
-      "dev": true,
-      "requires": {
-        "babel-helper-call-delegate": "6.24.1",
-        "babel-helper-get-function-arity": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "babel-template": "6.25.0",
-        "babel-traverse": "6.25.0",
-        "babel-types": "6.25.0"
-      }
-    },
-    "babel-plugin-transform-es2015-shorthand-properties": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
-      "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.25.0"
-      }
-    },
-    "babel-plugin-transform-es2015-spread": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
-      "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.23.0"
-      }
-    },
-    "babel-plugin-transform-es2015-sticky-regex": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
-      "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
-      "dev": true,
-      "requires": {
-        "babel-helper-regex": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.25.0"
-      }
-    },
-    "babel-plugin-transform-es2015-template-literals": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
-      "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.23.0"
-      }
-    },
-    "babel-plugin-transform-es2015-typeof-symbol": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
-      "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.23.0"
-      }
-    },
-    "babel-plugin-transform-es2015-unicode-regex": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
-      "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
-      "dev": true,
-      "requires": {
-        "babel-helper-regex": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "regexpu-core": "2.0.0"
-      }
-    },
-    "babel-plugin-transform-object-rest-spread": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.23.0.tgz",
-      "integrity": "sha1-h11ryb52HFiirj/u5dxIldjH+SE=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-syntax-object-rest-spread": "6.13.0",
-        "babel-runtime": "6.23.0"
-      }
-    },
-    "babel-plugin-transform-regenerator": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.24.1.tgz",
-      "integrity": "sha1-uNowWtQ8PJm0hI5P5AN7dw0jxBg=",
-      "dev": true,
-      "requires": {
-        "regenerator-transform": "0.9.11"
-      }
-    },
-    "babel-plugin-transform-strict-mode": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
-      "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.25.0"
-      }
-    },
-    "babel-polyfill": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.23.0.tgz",
-      "integrity": "sha1-g2TKYt+Or7gwSZ9pkXdGbDsDSZ0=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "core-js": "2.4.1",
-        "regenerator-runtime": "0.10.5"
-      }
-    },
-    "babel-preset-es2015": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
-      "integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-check-es2015-constants": "6.22.0",
-        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoping": "6.24.1",
-        "babel-plugin-transform-es2015-classes": "6.24.1",
-        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
-        "babel-plugin-transform-es2015-destructuring": "6.23.0",
-        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
-        "babel-plugin-transform-es2015-for-of": "6.23.0",
-        "babel-plugin-transform-es2015-function-name": "6.24.1",
-        "babel-plugin-transform-es2015-literals": "6.22.0",
-        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "babel-plugin-transform-es2015-modules-commonjs": "6.24.1",
-        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
-        "babel-plugin-transform-es2015-modules-umd": "6.24.1",
-        "babel-plugin-transform-es2015-object-super": "6.24.1",
-        "babel-plugin-transform-es2015-parameters": "6.24.1",
-        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-        "babel-plugin-transform-es2015-spread": "6.22.0",
-        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-        "babel-plugin-transform-es2015-template-literals": "6.22.0",
-        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
-        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-        "babel-plugin-transform-regenerator": "6.24.1"
-      }
-    },
-    "babel-register": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.24.1.tgz",
-      "integrity": "sha1-fhDhOi9xBlvfrVoXh7pFvKbe118=",
-      "dev": true,
-      "requires": {
-        "babel-core": "6.25.0",
-        "babel-runtime": "6.23.0",
-        "core-js": "2.4.1",
-        "home-or-tmp": "2.0.0",
-        "lodash": "4.17.4",
-        "mkdirp": "0.5.1",
-        "source-map-support": "0.4.15"
       }
     },
     "babel-runtime": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
       "integrity": "sha1-CpSJ8UTecO+zzkMArM2zKeL8VDs=",
+      "dev": true,
       "requires": {
         "core-js": "2.4.1",
         "regenerator-runtime": "0.10.5"
-      }
-    },
-    "babel-template": {
-      "version": "6.25.0",
-      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
-      "integrity": "sha1-ZlJBFmt8KqTGGdceGSlpVSsQwHE=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "babel-traverse": "6.25.0",
-        "babel-types": "6.25.0",
-        "babylon": "6.17.4",
-        "lodash": "4.17.4"
       }
     },
     "babel-traverse": {
       "version": "6.25.0",
       "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
       "integrity": "sha1-IldJfi/NGbie3BPEyROB+VEklvE=",
+      "dev": true,
       "requires": {
         "babel-code-frame": "6.22.0",
         "babel-messages": "6.23.0",
         "babel-runtime": "6.23.0",
         "babel-types": "6.25.0",
-        "babylon": "6.17.4",
+        "babylon": "6.18.0",
         "debug": "2.6.8",
         "globals": "9.18.0",
         "invariant": "2.2.2",
         "lodash": "4.17.4"
+      },
+      "dependencies": {
+        "babylon": {
+          "version": "6.18.0",
+          "resolved": "https://npm.corp.indeed.com/repository/npm/babylon/-/babylon-6.18.0.tgz",
+          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+          "dev": true
+        }
       }
     },
     "babel-types": {
       "version": "6.25.0",
       "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
       "integrity": "sha1-cK+ySNVmDl0Y+BHZHIMDtUE0oY4=",
+      "dev": true,
       "requires": {
         "babel-runtime": "6.23.0",
         "esutils": "2.0.2",
@@ -726,9 +1189,9 @@
       }
     },
     "babylon": {
-      "version": "6.17.4",
-      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz",
-      "integrity": "sha512-kChlV+0SXkjE0vUn9OZ7pBMWRFd8uq3mZe8x1K6jhuNcAFAtEnjchFAqB+dYEXKyd+JpT6eppRR78QAr5gTsUw=="
+      "version": "7.0.0-beta.44",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/babylon/-/babylon-7.0.0-beta.44.tgz",
+      "integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g=="
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -761,11 +1224,20 @@
       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
       "dev": true,
-      "optional": true,
       "requires": {
         "expand-range": "1.8.2",
         "preserve": "0.2.0",
         "repeat-element": "1.1.2"
+      }
+    },
+    "browserslist": {
+      "version": "3.2.5",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/browserslist/-/browserslist-3.2.5.tgz",
+      "integrity": "sha512-svi6zUwlR6uiQRwShFfNMSEWzwttsVqSFEcqlLOWsgJ4tYk0goE2KLNGzctsLUU3E1AGpES0cgiyzkvuFNIRIg==",
+      "dev": true,
+      "requires": {
+        "caniuse-lite": "1.0.30000830",
+        "electron-to-chromium": "1.3.42"
       }
     },
     "builtin-modules": {
@@ -792,6 +1264,12 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
       "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+    },
+    "caniuse-lite": {
+      "version": "1.0.30000830",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/caniuse-lite/-/caniuse-lite-1.0.30000830.tgz",
+      "integrity": "sha512-yMqGkujkoOIZfvOYiWdqPALgY/PVGiqCHUJb6yNq7xhI/pR+gQO0U2K6lRDqAiJv4+CIU3CtTLblNGw0QGnr6g==",
+      "dev": true
     },
     "chai": {
       "version": "3.5.0",
@@ -886,6 +1364,19 @@
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
+    "color-convert": {
+      "version": "1.9.1",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/color-convert/-/color-convert-1.9.1.tgz",
+      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+    },
     "colors": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
@@ -899,6 +1390,12 @@
       "requires": {
         "graceful-readlink": "1.0.1"
       }
+    },
+    "commondir": {
+      "version": "1.0.1",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+      "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
@@ -965,7 +1462,8 @@
     "core-js": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-      "integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4="
+      "integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4=",
+      "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -990,6 +1488,7 @@
       "version": "2.6.8",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
       "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+      "dev": true,
       "requires": {
         "ms": "2.0.0"
       }
@@ -1050,15 +1549,6 @@
         }
       }
     },
-    "detect-indent": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
-      "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
-      "dev": true,
-      "requires": {
-        "repeating": "2.0.1"
-      }
-    },
     "diff": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
@@ -1090,6 +1580,12 @@
       "requires": {
         "readable-stream": "1.1.14"
       }
+    },
+    "electron-to-chromium": {
+      "version": "1.3.42",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/electron-to-chromium/-/electron-to-chromium-1.3.42.tgz",
+      "integrity": "sha1-lcM78B0MxAVVauyJn+Yf1NduoPk=",
+      "dev": true
     },
     "encoding": {
       "version": "0.1.12",
@@ -1328,7 +1824,6 @@
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
       "dev": true,
-      "optional": true,
       "requires": {
         "is-posix-bracket": "0.1.1"
       }
@@ -1338,7 +1833,6 @@
       "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "dev": true,
-      "optional": true,
       "requires": {
         "fill-range": "2.2.3"
       }
@@ -1348,7 +1842,6 @@
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
       "dev": true,
-      "optional": true,
       "requires": {
         "is-extglob": "1.0.0"
       }
@@ -1408,21 +1901,30 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
       "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "fill-range": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
       "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
       "dev": true,
-      "optional": true,
       "requires": {
         "is-number": "2.1.0",
         "isobject": "2.1.0",
         "randomatic": "1.1.7",
         "repeat-element": "1.1.2",
         "repeat-string": "1.6.1"
+      }
+    },
+    "find-cache-dir": {
+      "version": "1.0.0",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
+      "integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
+      "dev": true,
+      "requires": {
+        "commondir": "1.0.1",
+        "make-dir": "1.2.0",
+        "pkg-dir": "2.0.0"
       }
     },
     "find-up": {
@@ -1450,15 +1952,13 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
       "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "for-own": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
       "dev": true,
-      "optional": true,
       "requires": {
         "for-in": "1.0.2"
       }
@@ -2447,7 +2947,6 @@
       "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "dev": true,
-      "optional": true,
       "requires": {
         "glob-parent": "2.0.0",
         "is-glob": "2.0.1"
@@ -2465,7 +2964,8 @@
     "globals": {
       "version": "9.18.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
+      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+      "dev": true
     },
     "globby": {
       "version": "5.0.0",
@@ -2562,6 +3062,11 @@
         "ansi-regex": "2.1.1"
       }
     },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+    },
     "has-gulplog": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
@@ -2571,14 +3076,10 @@
       }
     },
     "home-or-tmp": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
-      "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
-      "dev": true,
-      "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
-      }
+      "version": "3.0.0",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/home-or-tmp/-/home-or-tmp-3.0.0.tgz",
+      "integrity": "sha1-V6j+JM8zzdUkhgoVgh3cJchmcfs=",
+      "dev": true
     },
     "hosted-git-info": {
       "version": "2.4.2",
@@ -2683,15 +3184,13 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
       "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "is-equal-shallow": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "dev": true,
-      "optional": true,
       "requires": {
         "is-primitive": "2.0.0"
       }
@@ -2700,23 +3199,13 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
       "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "is-extglob": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
       "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
       "dev": true
-    },
-    "is-finite": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-      "dev": true,
-      "requires": {
-        "number-is-nan": "1.0.1"
-      }
     },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
@@ -2752,7 +3241,6 @@
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
       "dev": true,
-      "optional": true,
       "requires": {
         "kind-of": "3.2.2"
       }
@@ -2781,12 +3269,17 @@
         "path-is-inside": "1.0.2"
       }
     },
+    "is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+      "dev": true
+    },
     "is-posix-bracket": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
       "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "is-primitive": {
       "version": "2.0.0",
@@ -2824,7 +3317,6 @@
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
       "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
       "dev": true,
-      "optional": true,
       "requires": {
         "isarray": "1.0.0"
       },
@@ -2833,8 +3325,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -2876,12 +3367,6 @@
         "argparse": "1.0.9",
         "esprima": "3.1.3"
       }
-    },
-    "jsesc": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-      "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
-      "dev": true
     },
     "json-stable-stringify": {
       "version": "1.0.1",
@@ -2953,6 +3438,24 @@
         "pify": "2.3.0",
         "pinkie-promise": "2.0.1",
         "strip-bom": "2.0.0"
+      }
+    },
+    "locate-path": {
+      "version": "2.0.0",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/locate-path/-/locate-path-2.0.0.tgz",
+      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+      "dev": true,
+      "requires": {
+        "p-locate": "2.0.0",
+        "path-exists": "3.0.0"
+      },
+      "dependencies": {
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://npm.corp.indeed.com/repository/npm/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "dev": true
+        }
       }
     },
     "lodash": {
@@ -3109,12 +3612,28 @@
       "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
       "dev": true
     },
+    "make-dir": {
+      "version": "1.2.0",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/make-dir/-/make-dir-1.2.0.tgz",
+      "integrity": "sha512-aNUAa4UMg/UougV25bbrU4ZaaKNjJ/3/xnvg/twpmKROPdKZPZ9wGgI0opdZzO8q/zUFawoUuixuOv33eZ61Iw==",
+      "dev": true,
+      "requires": {
+        "pify": "3.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://npm.corp.indeed.com/repository/npm/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        }
+      }
+    },
     "micromatch": {
       "version": "2.3.11",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
       "dev": true,
-      "optional": true,
       "requires": {
         "arr-diff": "2.0.0",
         "array-unique": "0.2.1",
@@ -3260,6 +3779,12 @@
       "dev": true,
       "optional": true
     },
+    "node-modules-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
+      "integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=",
+      "dev": true
+    },
     "normalize-package-data": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.8.tgz",
@@ -3276,7 +3801,6 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
-      "optional": true,
       "requires": {
         "remove-trailing-separator": "1.0.2"
       }
@@ -3296,7 +3820,6 @@
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "dev": true,
-      "optional": true,
       "requires": {
         "for-own": "0.1.5",
         "is-extendable": "0.1.1"
@@ -3344,37 +3867,35 @@
         "lcid": "1.0.0"
       }
     },
-    "os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-      "dev": true
-    },
-    "output-file-sync": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
-      "integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
+    "p-limit": {
+      "version": "1.2.0",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/p-limit/-/p-limit-1.2.0.tgz",
+      "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "mkdirp": "0.5.1",
-        "object-assign": "4.1.1"
-      },
-      "dependencies": {
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-          "dev": true
-        }
+        "p-try": "1.0.0"
       }
+    },
+    "p-locate": {
+      "version": "2.0.0",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/p-locate/-/p-locate-2.0.0.tgz",
+      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "dev": true,
+      "requires": {
+        "p-limit": "1.2.0"
+      }
+    },
+    "p-try": {
+      "version": "1.0.0",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+      "dev": true
     },
     "parse-glob": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
       "dev": true,
-      "optional": true,
       "requires": {
         "glob-base": "0.3.0",
         "is-dotfile": "1.0.3",
@@ -3409,6 +3930,12 @@
       "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
       "dev": true
     },
+    "path-parse": {
+      "version": "1.0.5",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/path-parse/-/path-parse-1.0.5.tgz",
+      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+      "dev": true
+    },
     "path-type": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
@@ -3437,6 +3964,35 @@
         "pinkie": "2.0.4"
       }
     },
+    "pirates": {
+      "version": "3.0.2",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/pirates/-/pirates-3.0.2.tgz",
+      "integrity": "sha512-c5CgUJq6H2k6MJz72Ak1F5sN9n9wlSlJyEnwvpm9/y3WB4E3pHBDT2c6PEiS1vyJvq2bUxUAIu0EGf8Cx4Ic7Q==",
+      "dev": true,
+      "requires": {
+        "node-modules-regexp": "1.0.0"
+      }
+    },
+    "pkg-dir": {
+      "version": "2.0.0",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/pkg-dir/-/pkg-dir-2.0.0.tgz",
+      "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+      "dev": true,
+      "requires": {
+        "find-up": "2.1.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://npm.corp.indeed.com/repository/npm/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "2.0.0"
+          }
+        }
+      }
+    },
     "pluralize": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
@@ -3453,8 +4009,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "private": {
       "version": "0.1.7",
@@ -3478,7 +4033,6 @@
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
       "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
       "dev": true,
-      "optional": true,
       "requires": {
         "is-number": "3.0.0",
         "kind-of": "4.0.0"
@@ -3489,7 +4043,6 @@
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
-          "optional": true,
           "requires": {
             "kind-of": "3.2.2"
           },
@@ -3499,7 +4052,6 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
-              "optional": true,
               "requires": {
                 "is-buffer": "1.1.5"
               }
@@ -3511,7 +4063,6 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
-          "optional": true,
           "requires": {
             "is-buffer": "1.1.5"
           }
@@ -3616,79 +4167,44 @@
         "mute-stream": "0.0.5"
       }
     },
-    "regenerate": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
-      "integrity": "sha1-0ZQcZ7rUN+G+dkM63Vs4X5WxkmA=",
-      "dev": true
+    "regenerate-unicode-properties": {
+      "version": "5.1.3",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/regenerate-unicode-properties/-/regenerate-unicode-properties-5.1.3.tgz",
+      "integrity": "sha512-Yjy6t7jFQczDhYE+WVm7pg6gWYE258q4sUkk9qDErwXJIqx7jU9jGrMFHutJK/SRfcg7MEkXjGaYiVlOZyev/A==",
+      "dev": true,
+      "requires": {
+        "regenerate": "1.3.3"
+      },
+      "dependencies": {
+        "regenerate": {
+          "version": "1.3.3",
+          "resolved": "https://npm.corp.indeed.com/repository/npm/regenerate/-/regenerate-1.3.3.tgz",
+          "integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg==",
+          "dev": true
+        }
+      }
     },
     "regenerator-runtime": {
       "version": "0.10.5",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-      "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
-    },
-    "regenerator-transform": {
-      "version": "0.9.11",
-      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.11.tgz",
-      "integrity": "sha1-On0GdSDLe3F2dp61/4aGkb7+EoM=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.25.0",
-        "private": "0.1.7"
-      }
+      "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
+      "dev": true
     },
     "regex-cache": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
       "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
       "dev": true,
-      "optional": true,
       "requires": {
         "is-equal-shallow": "0.1.3",
         "is-primitive": "2.0.0"
-      }
-    },
-    "regexpu-core": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
-      "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
-      "dev": true,
-      "requires": {
-        "regenerate": "1.3.2",
-        "regjsgen": "0.2.0",
-        "regjsparser": "0.1.5"
-      }
-    },
-    "regjsgen": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-      "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
-      "dev": true
-    },
-    "regjsparser": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
-      "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
-      "dev": true,
-      "requires": {
-        "jsesc": "0.5.0"
-      },
-      "dependencies": {
-        "jsesc": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
-          "dev": true
-        }
       }
     },
     "remove-trailing-separator": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz",
       "integrity": "sha1-abBi2XhyetFNxrVrpKt3L9jXBRE=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "repeat-element": {
       "version": "1.1.2",
@@ -3700,17 +4216,7 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-      "dev": true,
-      "optional": true
-    },
-    "repeating": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-      "dev": true,
-      "requires": {
-        "is-finite": "1.0.2"
-      }
+      "dev": true
     },
     "replace-ext": {
       "version": "0.0.1",
@@ -3735,6 +4241,15 @@
       "requires": {
         "caller-path": "0.1.0",
         "resolve-from": "1.0.1"
+      }
+    },
+    "resolve": {
+      "version": "1.7.1",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/resolve/-/resolve-1.7.1.tgz",
+      "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
+      "dev": true,
+      "requires": {
+        "path-parse": "1.0.5"
       }
     },
     "resolve-from": {
@@ -3844,13 +4359,12 @@
     "source-map": {
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-      "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
-      "dev": true
+      "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
     },
     "source-map-support": {
-      "version": "0.4.15",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.15.tgz",
-      "integrity": "sha1-AyAt9lwG0r2MfsI2KhkwVv7407E=",
+      "version": "0.4.18",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/source-map-support/-/source-map-support-0.4.18.tgz",
+      "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
       "dev": true,
       "requires": {
         "source-map": "0.5.6"
@@ -4024,7 +4538,8 @@
     "to-fast-properties": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
+      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+      "dev": true
     },
     "to-iso-string": {
       "version": "0.0.2",
@@ -4035,8 +4550,7 @@
     "trim-right": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
-      "dev": true
+      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
     },
     "tryit": {
       "version": "1.0.3",
@@ -4065,10 +4579,32 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
-    "user-home": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-      "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
+    "unicode-canonical-property-names-ecmascript": {
+      "version": "1.0.3",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.3.tgz",
+      "integrity": "sha512-iG/2t0F2LAU8aZYPkX5gi7ebukHnr3sWFESpb+zPQeeaQwOkfoO6ZW17YX7MdRPNG9pCy+tjzGill+Ah0Em0HA==",
+      "dev": true
+    },
+    "unicode-match-property-ecmascript": {
+      "version": "1.0.3",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.3.tgz",
+      "integrity": "sha512-nFcaBFcr08UQNF15ZgI5ISh3yUnQm7SJRRxwYrL5VYX46pS+6Q7TCTv4zbK+j6/l7rQt0mMiTL2zpmeygny6rA==",
+      "dev": true,
+      "requires": {
+        "unicode-canonical-property-names-ecmascript": "1.0.3",
+        "unicode-property-aliases-ecmascript": "1.0.3"
+      }
+    },
+    "unicode-match-property-value-ecmascript": {
+      "version": "1.0.1",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.0.1.tgz",
+      "integrity": "sha512-lM8B0FDZQh9yYGgiabRQcyWicB27VLOolSBRIxsO7FeQPtg+79Oe7sC8Mzr8BObDs+G9CeYmC/shHo6OggNEog==",
+      "dev": true
+    },
+    "unicode-property-aliases-ecmascript": {
+      "version": "1.0.3",
+      "resolved": "https://npm.corp.indeed.com/repository/npm/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.3.tgz",
+      "integrity": "sha512-TdDmDOTxEf2ad1g3ZBpM6cqKIb2nJpVlz1Q++casDryKz18tpeMBhSng9hjC1CTQCkOV9Rw2knlSB6iRo7ad1w==",
       "dev": true
     },
     "util": {
@@ -4092,15 +4628,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
-    },
-    "v8flags": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
-      "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
-      "dev": true,
-      "requires": {
-        "user-home": "1.1.1"
-      }
     },
     "validate-npm-package-license": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lib"
   ],
   "scripts": {
-    "test": "mocha --compilers js:babel-core/register tests/tests.js",
+    "test": "mocha --compilers js:@babel/register tests/tests.js",
     "lint": "eslint src",
     "clean": "rimraf lib",
     "dev": "babel -w --out-dir lib src",
@@ -41,8 +41,8 @@
   },
   "homepage": "https://github.com/laget-se/react-gettext-parser#readme",
   "dependencies": {
-    "babel-traverse": "^6.7.4",
-    "babylon": "^6.7.0",
+    "@babel/traverse": "7.0.0-beta.44",
+    "babylon": "^7.0.0-beta.44",
     "colors": "^1.1.2",
     "deep-extend": "^0.4.1",
     "gettext-parser": "^1.1.2",
@@ -55,10 +55,12 @@
     "yargs": "^4.4.0"
   },
   "devDependencies": {
-    "babel-cli": "^6.6.5",
+    "@babel/cli": "7.0.0-beta.44",
+    "@babel/core": "7.0.0-beta.44",
+    "@babel/plugin-proposal-object-rest-spread": "7.0.0-beta.44",
+    "@babel/preset-env": "7.0.0-beta.44",
+    "@babel/register": "^7.0.0-beta.44",
     "babel-eslint": "^6.0.2",
-    "babel-plugin-transform-object-rest-spread": "^6.6.5",
-    "babel-preset-es2015": "^6.6.0",
     "chai": "^3.5.0",
     "eslint": "^2.7.0",
     "eslint-config-airbnb": "^6.2.0",

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -1,4 +1,3 @@
-
 // Default mappings between function arguments and their corresponding
 // .pot keys
 export const GETTEXT_FUNC_ARGS_MAP = {
@@ -28,7 +27,6 @@ export const BABEL_PARSING_OPTS = {
   sourceType: 'module',
   plugins: [
     'jsx',
-    'flow',
     'asyncFunctions',
     'classConstructorCall',
     'doExpressions',

--- a/src/parse.js
+++ b/src/parse.js
@@ -13,6 +13,7 @@ import { isGettextFuncCall, isGettextComponent, getFuncName, getGettextStringFro
 const noop = () => {};
 
 export const TYPESCRIPT = 'TYPESCRIPT';
+export const JAVASCRIPT = 'JAVASCRIPT';
 
 const getEmptyBlock = () => ({
   msgctxt: '',
@@ -24,14 +25,8 @@ const getEmptyBlock = () => ({
   },
 });
 
-const isTypeScript = (opt) => {
-  if (opt.sourceType === TYPESCRIPT) return true;
-  if (opt.filename) return opt.filename.endsWith('.ts') || opt.filename.endsWith('.tsx');
-  return false;
-};
-
-const getBabelParsingOptions = (useTypeScript) => {
-  if (useTypeScript) {
+const getBabelParsingOptions = (sourceType) => {
+  if (sourceType === TYPESCRIPT) {
     return { ...BABEL_PARSING_OPTS, plugins: ['typescript'].concat(BABEL_PARSING_OPTS.plugins) };
   }
   return { ...BABEL_PARSING_OPTS, plugins: ['flow'].concat(BABEL_PARSING_OPTS.plugins) };
@@ -379,7 +374,7 @@ export const getTraverser = (cb = noop, opts = {}) => {
 export const extractMessages = (code, opts = {}) => {
   let blocks = [];
 
-  const ast = babylon.parse(code.toString('utf8'), getBabelParsingOptions(isTypeScript(opts)));
+  const ast = babylon.parse(code.toString('utf8'), getBabelParsingOptions(opts.sourceType));
   const traverser = getTraverser(_blocks => {
     blocks = _blocks;
   }, opts);
@@ -421,6 +416,7 @@ export const extractMessagesFromFile = (file, opts = {}) =>
   extractMessages(fs.readFileSync(file, 'utf8'), {
     ...opts,
     filename: file,
+    sourceType: (file.endsWith('.ts') || file.endsWith('.tsx')) ? TYPESCRIPT : JAVASCRIPT,
   });
 
 /**

--- a/src/parse.js
+++ b/src/parse.js
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import * as babylon from 'babylon';
-import traverse from 'babel-traverse';
+import traverse from '@babel/traverse';
 import curry from 'lodash.curry';
 import uniq from 'lodash.uniq';
 import glob from 'glob-all';
@@ -12,6 +12,8 @@ import { isGettextFuncCall, isGettextComponent, getFuncName, getGettextStringFro
 
 const noop = () => {};
 
+export const TYPESCRIPT = 'TYPESCRIPT';
+
 const getEmptyBlock = () => ({
   msgctxt: '',
   msgid: null,
@@ -21,6 +23,19 @@ const getEmptyBlock = () => ({
     extracted: [],
   },
 });
+
+const isTypeScript = (opt) => {
+  if (opt.sourceType === TYPESCRIPT) return true;
+  if (opt.filename) return opt.filename.endsWith('.ts') || opt.filename.endsWith('.tsx');
+  return false;
+};
+
+const getBabelParsingOptions = (useTypeScript) => {
+  if (useTypeScript) {
+    return { ...BABEL_PARSING_OPTS, plugins: ['typescript'].concat(BABEL_PARSING_OPTS.plugins) };
+  }
+  return { ...BABEL_PARSING_OPTS, plugins: ['flow'].concat(BABEL_PARSING_OPTS.plugins) };
+};
 
 /**
  * Returns a gettext block given a mapping of component props to gettext
@@ -364,7 +379,7 @@ export const getTraverser = (cb = noop, opts = {}) => {
 export const extractMessages = (code, opts = {}) => {
   let blocks = [];
 
-  const ast = babylon.parse(code.toString('utf8'), BABEL_PARSING_OPTS);
+  const ast = babylon.parse(code.toString('utf8'), getBabelParsingOptions(isTypeScript(opts)));
   const traverser = getTraverser(_blocks => {
     blocks = _blocks;
   }, opts);
@@ -422,7 +437,7 @@ export const extractMessagesFromGlob = (globArr, opts = {}) => {
  * Parses a string for gettext blocks and writes them to a .pot file
  */
 export const parse = (code, opts = {}, cb = noop) => {
-  const blocks = extractMessages(code);
+  const blocks = extractMessages(code, opts);
   outputPot(opts.output, toPot(blocks), cb);
 };
 

--- a/tests/fixtures/MergeD.tsx
+++ b/tests/fixtures/MergeD.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { GetText, gettext } from 'gettext-lib';
+
+// This is a unique key word in typescript, we use this to test the parser
+type T = {
+  readonly key: string
+}
+
+const MergeD = ()=>
+  <div>
+    { gettext("I'm both here and elsewhere") }
+  </div>;
+
+export default MergeD;

--- a/tests/fixtures/SingleString.ts
+++ b/tests/fixtures/SingleString.ts
@@ -1,0 +1,11 @@
+import { gettext } from 'gettext-lib';
+
+// This is a unique key word in typescript, we use this to test the parser
+type T = {
+  readonly key: string
+}
+
+const SimpleString = () =>
+    { return gettext("Translate me") };
+
+export default SimpleString;

--- a/tests/fixtures/SingleString.tsx
+++ b/tests/fixtures/SingleString.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { GetText, gettext } from 'gettext-lib';
+
+// This is a unique key word in typescript, we use this to test the parser
+type T = {
+  readonly key: string
+}
+
+const SimpleString = () =>
+  <div>
+    <GetText message="Translate me" />
+  </div>;
+
+export default SimpleString;

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -270,7 +270,6 @@ describe('react-gettext-parser', () => {
 
     it('should work with both js and ts source', () => {
       const messages = extractMessagesFromGlob('tests/fixtures/Merge{A,D}.{jsx,tsx}');
-      console.log(JSON.stringify(messages, null, 2));
       expect(messages).to.have.length(1);
       expect(messages[0].comments.reference).to.have.length(2);
     });

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -13,6 +13,7 @@ import {
   extractMessagesFromGlob,
   toPot,
 } from '../src/index.js';
+import { TYPESCRIPT } from '../src';
 
 const getSource = file => fs.readFileSync(path.join(__dirname, 'fixtures', file), 'utf8');
 const getJson = file => require(`./fixtures/${file}`);
@@ -267,6 +268,13 @@ describe('react-gettext-parser', () => {
       expect(references[2].filename).to.contain('MergeC.jsx');
     });
 
+    it('should work with both js and ts source', () => {
+      const messages = extractMessagesFromGlob('tests/fixtures/Merge{A,D}.{jsx,tsx}');
+      console.log(JSON.stringify(messages, null, 2));
+      expect(messages).to.have.length(1);
+      expect(messages[0].comments.reference).to.have.length(2);
+    });
+
   });
 
   describe('compiling to pot', () => {
@@ -300,6 +308,34 @@ describe('react-gettext-parser', () => {
       const pot = toPot(messages);
 
       expect(pot).to.contain('#: SingleString.jsx');
+    });
+
+  });
+
+  describe('typescript support', () => {
+
+    it('should extract a message from ts', () => {
+      const code = getSource('SingleString.tsx');
+      const messages = extractMessages(code, { sourceType: TYPESCRIPT });
+      const expected = getJson('SingleString.json');
+      expect(messages).to.have.length(1);
+      expect(messages[0].msgid).to.equal(expected[0].msgid);
+    });
+
+    it('should parse typescript', () => {
+      const messages = extractMessagesFromFile('tests/fixtures/SingleString.ts');
+      expect(messages).to.have.length(1);
+      const references = messages[0].comments.reference;
+      expect(references[0].line).to.equal(9);
+      expect(references[0].column).to.equal(13);
+    });
+
+    it('should parse typescript with jsx', () => {
+      const messages = extractMessagesFromFile('tests/fixtures/SingleString.tsx');
+      expect(messages).to.have.length(1);
+      const references = messages[0].comments.reference;
+      expect(references[0].line).to.equal(11);
+      expect(references[0].column).to.equal(4);
     });
 
   });


### PR DESCRIPTION
Hi, it's me again, recent we move some project to typescript and I think it's good to have ts support here:
As babel@7 supports typescript parsing, I do following things in this PR:

1. Upgrade to babel@7, this is done through https://github.com/babel/babel-upgrade
2. Add typescript parsing support via check input file extension, or use specify `option` with `sourceType: 'TYPESCRIPT'`
3. Add some test to verify it works well.

This won't change any behavior when input file as js/jsx or not specify the `sourceType`

As babel@7 is still beta, maybe this suit to a beta release.
Thanks.