### PR TITLE
Enabled export related proposal plugins

### DIFF
--- a/src/defaults.js
+++ b/src/defaults.js
@@ -35,6 +35,8 @@ export const BABEL_PARSING_OPTS = {
     'decorators',
     'classProperties',
     'exportExtensions',
+    'exportDefaultFrom',
+    'exportNamespaceFrom',
     'exponentiationOperator',
     'asyncGenerators',
     'functionBind',


### PR DESCRIPTION
Discussed in #39
This PR enables support for parsing `export * from ...` and  `export something from ...` statements.
