### PR TITLE
Fix parse error for Fragment short syntax <></> with direct text node

### DIFF
--- a/src/node-helpers.js
+++ b/src/node-helpers.js
@@ -6,11 +6,13 @@ export const isGettextFuncCall = (names, node) => (
 );
 
 export const isGettextComponent = (names, node) => {
+  // If it's not a JSXOpeningElement, it cannot be a GettextComponent.
+  // Without this check, the last return statment can throw an exception.
   if (!node || node.type !== 'JSXOpeningElement') {
     return false;
   }
   return names.indexOf(node.name.name) !== -1;
-}
+};
 
 export const getFuncName = node =>
   (node.callee.object ? node.callee.property.name : node.callee.name);

--- a/src/node-helpers.js
+++ b/src/node-helpers.js
@@ -5,8 +5,12 @@ export const isGettextFuncCall = (names, node) => (
     : names.indexOf(node.callee.name) !== -1
 );
 
-export const isGettextComponent = (names, node) =>
-  names.indexOf(node.name.name) !== -1;
+export const isGettextComponent = (names, node) => {
+  if (!node || node.type !== 'JSXOpeningElement') {
+    return false;
+  }
+  return names.indexOf(node.name.name) !== -1;
+}
 
 export const getFuncName = node =>
   (node.callee.object ? node.callee.property.name : node.callee.name);

--- a/src/parse.js
+++ b/src/parse.js
@@ -220,12 +220,7 @@ export const getTraverser = (cb = noop, opts = {}) => {
         const envOpts = state.opts || opts;
         const propsMap = envOpts.componentPropsMap || GETTEXT_COMPONENT_PROPS_MAP;
 
-        // parent.openingElement can be undefined when using fragment short syntax <>...</>
-        if (!parent.openingElement) {
-          return;
-        }
-
-        if (isGettextComponent(Object.keys(propsMap), parent.openingElement) === false) {
+        if (!isGettextComponent(Object.keys(propsMap), parent.openingElement)) {
           return;
         }
 
@@ -256,11 +251,7 @@ export const getTraverser = (cb = noop, opts = {}) => {
         const envOpts = state.opts || opts;
         const propsMap = envOpts.componentPropsMap || GETTEXT_COMPONENT_PROPS_MAP;
 
-        if (
-          parent.openingElement === undefined ||
-          parent.openingElement.type !== 'JSXOpeningElement' ||
-          isGettextComponent(Object.keys(propsMap), parent.openingElement) === false
-        ) {
+        if (!isGettextComponent(Object.keys(propsMap), parent.openingElement)) {
           return;
         }
 

--- a/src/parse.js
+++ b/src/parse.js
@@ -220,7 +220,7 @@ export const getTraverser = (cb = noop, opts = {}) => {
         const envOpts = state.opts || opts;
         const propsMap = envOpts.componentPropsMap || GETTEXT_COMPONENT_PROPS_MAP;
 
-        if (!isGettextComponent(Object.keys(propsMap), parent.openingElement)) {
+        if (isGettextComponent(Object.keys(propsMap), parent.openingElement) === false) {
           return;
         }
 
@@ -251,7 +251,7 @@ export const getTraverser = (cb = noop, opts = {}) => {
         const envOpts = state.opts || opts;
         const propsMap = envOpts.componentPropsMap || GETTEXT_COMPONENT_PROPS_MAP;
 
-        if (!isGettextComponent(Object.keys(propsMap), parent.openingElement)) {
+        if (isGettextComponent(Object.keys(propsMap), parent.openingElement) === false) {
           return;
         }
 

--- a/src/parse.js
+++ b/src/parse.js
@@ -220,10 +220,8 @@ export const getTraverser = (cb = noop, opts = {}) => {
         const envOpts = state.opts || opts;
         const propsMap = envOpts.componentPropsMap || GETTEXT_COMPONENT_PROPS_MAP;
 
-        // Using fragment short syntax <>...</> yields JSXText paths with
-        // whitespace content and no name property, so this check is best
-        // done before invoking isGettextComponent().
-        if (node.value.trim() === '') {
+        // parent.openingElement can be undefined when using fragment short syntax <>...</>
+        if (!parent.openingElement) {
           return;
         }
 

--- a/tests/fixtures/FragmentShortSyntax.js
+++ b/tests/fixtures/FragmentShortSyntax.js
@@ -4,6 +4,7 @@ import { gettext } from 'gettext-lib';
 const FragmentShortComponent = () => (
   <>
     { gettext('Fragment short syntax') }
+    some unrelated text
   </>
 );
 


### PR DESCRIPTION
When we try to parse fragment short syntax with direct text node like the following,
parse will fail with `TypeError: Cannot read property 'name' of undefined`.
```
import React, { Fragment } from 'react';
import { gettext } from 'gettext-lib';

const FragmentShortComponent = () => (
  <>
    { gettext('Fragment short syntax') }
    some unrelated text
  </>
);

export default FragmentShortComponent;
```
I also updated a test to cover this case.
Could you take a look?