### PR TITLE
Fix an issue with colon character within short fragment syntax

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -227,6 +227,10 @@ export const getTraverser = (cb = noop, opts = {}) => {
           return;
         }
 
+        if (!parent.openingElement) {
+          return;
+        }
+
         if (isGettextComponent(Object.keys(propsMap), parent.openingElement) === false) {
           return;
         }

--- a/tests/fixtures/FragmentShortSyntax.jsx
+++ b/tests/fixtures/FragmentShortSyntax.jsx
@@ -1,9 +1,9 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import { gettext } from 'gettext-lib';
 
 const FragmentShortComponent = () => (
   <>
-    { gettext('Fragment short syntax') }
+    { gettext('Fragment short syntax') }: {'foo'}
   </>
 );
 

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -400,7 +400,7 @@ describe('react-gettext-parser', () => {
 
   describe('ast parsing', () => {
     it('should support the React fragment short syntax <></>', () => {
-      const messages = extractMessagesFromFile('tests/fixtures/FragmentShortSyntax.js');
+      const messages = extractMessagesFromFile('tests/fixtures/FragmentShortSyntax.jsx');
       expect(messages.length).to.equal(1);
     });
   });


### PR DESCRIPTION
Fixed error:
`
2) react-gettext-parser
       ast parsing
         should support the React fragment short syntax <></>:
     TypeError: Cannot read property 'name' of undefined
      at name (src/node-helpers.js:9:22)
      at enter (src/parse.js:230:13)
      at NodePath._call (node_modules\@babel\traverse\lib\path\context.js:53:20)
      at NodePath.call (node_modules\@babel\traverse\lib\path\context.js:40:17)
      at NodePath.visit (node_modules\@babel\traverse\lib\path\context.js:88:12)
      at TraversalContext.visitQueue (node_modules\@babel\traverse\lib\context.js:118:16)
      at TraversalContext.visitMultiple (node_modules\@babel\traverse\lib\context.js:85:17)
      at TraversalContext.visit (node_modules\@babel\traverse\lib\context.js:144:19)
      at Function.traverse.node (node_modules\@babel\traverse\lib\index.js:94:17)
      at NodePath.visit (node_modules\@babel\traverse\lib\path\context.js:95:18)
      at TraversalContext.visitQueue (node_modules\@babel\traverse\lib\context.js:118:16)
      at TraversalContext.visitSingle (node_modules\@babel\traverse\lib\context.js:90:19)
      at TraversalContext.visit (node_modules\@babel\traverse\lib\context.js:146:19)
      at Function.traverse.node (node_modules\@babel\traverse\lib\index.js:94:17)
      at NodePath.visit (node_modules\@babel\traverse\lib\path\context.js:95:18)
      at TraversalContext.visitQueue (node_modules\@babel\traverse\lib\context.js:118:16)
      at TraversalContext.visitSingle (node_modules\@babel\traverse\lib\context.js:90:19)
      at TraversalContext.visit (node_modules\@babel\traverse\lib\context.js:146:19)
      at Function.traverse.node (node_modules\@babel\traverse\lib\index.js:94:17)
      at NodePath.visit (node_modules\@babel\traverse\lib\path\context.js:95:18)
      at TraversalContext.visitQueue (node_modules\@babel\traverse\lib\context.js:118:16)
      at TraversalContext.visitMultiple (node_modules\@babel\traverse\lib\context.js:85:17)
      at TraversalContext.visit (node_modules\@babel\traverse\lib\context.js:144:19)
      at Function.traverse.node (node_modules\@babel\traverse\lib\index.js:94:17)
      at NodePath.visit (node_modules\@babel\traverse\lib\path\context.js:95:18)
      at TraversalContext.visitQueue (node_modules\@babel\traverse\lib\context.js:118:16)
      at TraversalContext.visitMultiple (node_modules\@babel\traverse\lib\context.js:85:17)
      at TraversalContext.visit (node_modules\@babel\traverse\lib\context.js:144:19)
      at Function.traverse.node (node_modules\@babel\traverse\lib\index.js:94:17)
      at NodePath.visit (node_modules\@babel\traverse\lib\path\context.js:95:18)
      at TraversalContext.visitQueue (node_modules\@babel\traverse\lib\context.js:118:16)
      at TraversalContext.visitSingle (node_modules\@babel\traverse\lib\context.js:90:19)
      at TraversalContext.visit (node_modules\@babel\traverse\lib\context.js:146:19)
      at Function.traverse.node (node_modules\@babel\traverse\lib\index.js:94:17)
      at traverse (node_modules\@babel\traverse\lib\index.js:76:12)
      at extractMessages (src/parse.js:384:3)
      at extractMessages (src/parse.js:418:3)
      at Context.<anonymous> (tests/tests.js:403:24)
`