### PR TITLE
Extended babel configuration

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,6 +3,7 @@
     "@babel/preset-env"
   ],
   "plugins": [
-    "@babel/plugin-proposal-object-rest-spread"
+    "@babel/plugin-proposal-object-rest-spread",
+    "@babel/plugin-proposal-optional-chaining"
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -345,6 +345,24 @@
         }
       }
     },
+    "@babel/plugin-proposal-optional-chaining": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.6.0.tgz",
+      "integrity": "sha512-kj4gkZ6qUggkprRq3Uh5KP8XnE1MdIO0J7MhdDX8+rAbB6dJ2UrensGIS+0NPZAaaJ1Vr0PN6oLUgXMU1uMcSg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-optional-chaining": "^7.2.0"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
+          "integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA==",
+          "dev": true
+        }
+      }
+    },
     "@babel/plugin-proposal-unicode-property-regex": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.2.0.tgz",
@@ -411,6 +429,23 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.2.0.tgz",
       "integrity": "sha512-bDe4xKNhb0LI7IvZHiA13kff0KEfaGX/Hv4lMA9+7TEc63hMNvfKo6ZFpXhKuEp+II/q35Gc4NoMeDZyaUbj9w==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
+          "integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/plugin-syntax-optional-chaining": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.2.0.tgz",
+      "integrity": "sha512-HtGCtvp5Uq/jH/WNUPkK6b7rufnCPLLlDAFN7cmACoIjaOOiXxUt3SswU5loHqrhtqTsa/WoLQ1OQ1AGuZqaWA==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "@babel/cli": "^7.2.0",
     "@babel/core": "^7.2.0",
     "@babel/plugin-proposal-object-rest-spread": "7.0.0-beta.44",
+    "@babel/plugin-proposal-optional-chaining": "^7.6.0",
     "@babel/preset-env": "^7.2.0",
     "@babel/register": "^7.0.0-beta.44",
     "babel-eslint": "^10.0.2",

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -42,5 +42,6 @@ export const BABEL_PARSING_OPTS = {
     'functionBind',
     'functionSent',
     'dynamicImport',
+    'optionalChaining'
   ],
 }

--- a/tests/fixtures/OptionalChaining.js
+++ b/tests/fixtures/OptionalChaining.js
@@ -1,0 +1,12 @@
+import { gettext } from 'gettext-lib';
+
+const someObject = {
+  just: {}
+};
+
+const OptionalChaining = () => {
+  const usage = someObject.just?.to.test.optionalChaining;
+  gettext('Optional chaining works');
+};
+
+export default OptionalChaining;

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -500,4 +500,13 @@ describe('react-gettext-parser', () => {
       expect(messages[0].msgid).to.equal(expected[0].msgid)
     })
   })
+
+  describe('optional chaining support', () => {
+    it('should parse javascript that contains optional chaining', () => {
+      const code = getSource('OptionalChaining.js')
+      const messages = extractMessages(code)
+      expect(messages).to.have.length(1)
+      expect(messages[0].msgid).to.equal('Optional chaining works')
+    })
+  })
 })


### PR DESCRIPTION
This PR would add default support for optional chaining notation to the parser.
Optional chaining is in stage 3 and is already turned on by default with frameworks like `react-native`.

Without support for it my React Native project can't be parsed using this library.

---
For everyone not familiar with optional chaining here's an example:
`const data = object.without?.data`

This way we can safely access data variable even if `object.without` would be `undefined`. In other words it lets programmer skip cumbersome checks like `const data = object.without && object.without.data;`.

