### PR TITLE
adds disable line numbers option

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,13 +46,14 @@ The entire help section for ya:
 react-gettext-parser <options> glob [, glob, ...]
 
 Options:
-  -h, --help       Show help                                          [boolean]
-  -o, --output     Path to output .pot file
-  -c, --config     Path to a react-gettext-parser config file
-  --trim           Trims extracted strings from surrounding whitespace[boolean]
-  --trim-lines     Trims each line in extracted strings from surrounding
-                   whitespace                                         [boolean]
-  --trim-newlines  Trims extracted strings from new-lines             [boolean]
+  -h, --help             Show help                                          [boolean]
+  -o, --output           Path to output .pot file
+  -c, --config           Path to a react-gettext-parser config file
+  --trim                 Trims extracted strings from surrounding whitespace[boolean]
+  --trim-lines           Trims each line in extracted strings from surrounding
+                         whitespace                                         [boolean]
+  --trim-newlines        Trims extracted strings from new-lines             [boolean]
+  --disable-line-numbers Disables line number ouput in .pot file            [boolean]
 ```
 
 ### Using the API
@@ -284,6 +285,12 @@ Default: `false`
 ##### `trimNewlines` (`--trim-newlines`)
 
 Trims extracted strings from new-lines.
+
+Default: `false`
+
+##### `disableLineNumbers` (`--disable-line-numbers`)
+
+Disables line number ouput in .pot file
 
 Default: `false`
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -28,6 +28,10 @@ const args = yargs
   .option('trim-newlines', {
     type: 'boolean',
     description: 'Trims extracted strings from new-lines',
+  })
+  .option('disable-line-numbers', {
+    type: 'boolean',
+    description: 'Disables line numbers in POT reference comments',
   }).argv
 
 const filesGlob = args._
@@ -37,6 +41,7 @@ let opts = {
   trim: args.trim,
   trimLines: args['trim-lines'],
   trimNewlines: args['trim-newlines'],
+  disableLineNumbers: args['disable-line-numbers'],
 }
 
 if (args.config) {

--- a/src/json2pot.js
+++ b/src/json2pot.js
@@ -29,22 +29,24 @@ const createTranslationsTable = (blocks, headers = {}) => {
   }
 }
 
-const convertReferenceToString = reference =>
-  `${reference.filename}:${reference.line}`
+const convertReferenceToString = (reference, disableLineNumbers) =>
+disableLineNumbers
+    ? `${reference.filename}`
+    : `${reference.filename}:${reference.line}`;
 
-const convertCommentArraysToStrings = blocks =>
+const convertCommentArraysToStrings = (blocks, disableLineNumbers=false) =>
   blocks.map(b => ({
     ...b,
     comments: {
       reference: b.comments.reference
-        .map(ref => convertReferenceToString(ref))
+        .map(ref => convertReferenceToString(ref, disableLineNumbers))
         .join('\n'),
       extracted: b.comments.extracted.join('\n'),
     },
   }))
 
 export const toPot = (blocks, opts = {}) => {
-  const parsedBlocks = convertCommentArraysToStrings(blocks)
+  const parsedBlocks = convertCommentArraysToStrings(blocks, opts.disableLineNumbers)
   const potJson = createTranslationsTable(parsedBlocks)
 
   // Allow the consumer to transform headers

--- a/src/parse.js
+++ b/src/parse.js
@@ -480,7 +480,10 @@ export const parse = (code, opts = {}, cb = noop) => {
   const blocks = extractMessages(code, opts)
   outputPot(
     opts.output,
-    toPot(blocks, { transformHeaders: opts.transformHeaders }),
+    toPot(blocks, {
+      transformHeaders: opts.transformHeaders,
+      disableLineNumbers: opts.disableLineNumbers,
+     }),
     cb
   )
 }
@@ -493,7 +496,10 @@ export const parseFile = (file, opts = {}, cb = noop) => {
   const blocks = extractMessagesFromFile(file, opts)
   outputPot(
     opts.output,
-    toPot(blocks, { transformHeaders: opts.transformHeaders }),
+    toPot(blocks, {
+      transformHeaders: opts.transformHeaders,
+      disableLineNumbers: opts.disableLineNumbers,
+     }),
     cb
   )
 }
@@ -506,7 +512,10 @@ export const parseGlob = (globArr, opts = {}, cb = noop) => {
   const blocks = extractMessagesFromGlob(globArr, opts)
   outputPot(
     opts.output,
-    toPot(blocks, { transformHeaders: opts.transformHeaders }),
+    toPot(blocks, {
+      transformHeaders: opts.transformHeaders,
+      disableLineNumbers: opts.disableLineNumbers,
+     }),
     cb
   )
 }

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -358,6 +358,14 @@ describe('react-gettext-parser', () => {
       expect(compileSpy.called).to.equal(true)
     })
 
+    it('should allow line numbers to be disabled', () => {
+      const messages = extractMessagesFromFile('tests/fixtures/SingleString.js')
+      const pot = toPot(messages, {disableLineNumbers: true});
+      const reference = pot.split('\n')
+        .find(line => line.startsWith('#: tests/fixtures/SingleString.js'));
+      expect(reference).to.equal('#: tests/fixtures/SingleString.js');
+    })
+    
     describe('should allow for transform of headers', () => {
       let transformHeaders = null
       const customHeaders = {


### PR DESCRIPTION
Resolves #25 

1. Adds `--disable-line-numbers` cli switch
2. Adds this option to `toPot` options object
    * + `convertCommentArraysToStrings`
    * + `convertReferenceToString`
3. Adds test
4. Update readme