### PR TITLE
Update @babel/parser@7.9.4 to parse `as const`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -276,9 +276,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.3.4.tgz",
-      "integrity": "sha512-tXZCqWtlOOP4wgCp6RjRvLmfuhnqTLy9VHwRochJBCP2nDm27JnnuFEnXFASVyQNHk36jD1tAammsCEEqgscIQ=="
+      "version": "7.9.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.4.tgz",
+      "integrity": "sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA=="
     },
     "@babel/plugin-proposal-async-generator-functions": {
       "version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "homepage": "https://github.com/laget-se/react-gettext-parser#readme",
   "dependencies": {
-    "@babel/parser": "^7.3.4",
+    "@babel/parser": "^7.9.4",
     "@babel/traverse": "^7.3.4",
     "colors": "^1.1.2",
     "convert-newline": "0.0.5",

--- a/tests/fixtures/AsConst.ts
+++ b/tests/fixtures/AsConst.ts
@@ -1,0 +1,8 @@
+import { gettext } from 'gettext-lib'
+
+const AsConst = () => {
+  const strs = [gettext('Translate me') as string, 'raw string'] as const
+  return strs
+}
+
+export default AsConst

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -498,6 +498,14 @@ describe('react-gettext-parser', () => {
       expect(references[0].column).to.equal(13)
     })
 
+    it('should parse typescript including `as const` syntax', () => {
+      const messages = extractMessagesFromFile('tests/fixtures/AsConst.ts')
+      expect(messages).to.have.length(1)
+      const references = messages[0].comments.reference
+      expect(references[0].line).to.equal(4)
+      expect(references[0].column).to.equal(16)
+    })
+
     it('should parse typescript with jsx', () => {
       const messages = extractMessagesFromFile(
         'tests/fixtures/SingleString.tsx'


### PR DESCRIPTION
`as const` synatx cannot be parsed in the current version of `@babel/parser`.

I upgraded `@babel/parser` and added test for it.

Could you review, merge and publish new version if it looks good?

Thanks as always.