### PR TITLE
add pipeline operator support

### DIFF
--- a/src/defaults.js
+++ b/src/defaults.js
@@ -44,5 +44,6 @@ export const BABEL_PARSING_OPTS = {
     'dynamicImport',
     'optionalChaining',
     'nullishCoalescingOperator',
+    ['pipelineOperator', { 'proposal': 'minimal' }],
   ],
 }

--- a/tests/fixtures/PipelineOperator.js
+++ b/tests/fixtures/PipelineOperator.js
@@ -1,0 +1,10 @@
+import { gettext } from 'gettext-lib';
+
+const functionMock = (param) => param;
+
+const PipelineOpeartor = () => {
+  const usage = 'Foo' |> functionMock;
+  gettext('Optional chaining works');
+};
+
+export default PipelineOpeartor;

--- a/tests/fixtures/PipelineOperator.js
+++ b/tests/fixtures/PipelineOperator.js
@@ -1,10 +1,10 @@
 import { gettext } from 'gettext-lib';
 
-const functionMock = (param) => param;
+const functionMock = _ => _;
 
 const PipelineOpeartor = () => {
   const usage = 'Foo' |> functionMock;
-  gettext('Optional chaining works');
+  gettext('Pipeline operator works');
 };
 
 export default PipelineOpeartor;

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -544,4 +544,13 @@ describe('react-gettext-parser', () => {
       expect(messages[0].msgid).to.equal('Nullish coalescing works')
     })
   })
+
+  describe('pipeline operator support', () => {
+    it('should parse javascript that contains pipeline operator', () => {
+      const code = getSource('PipelineOperator.js')
+      const messages = extractMessages(code)
+      expect(messages).to.have.length(1)
+      expect(messages[0].msgid).to.equal('Pipeline operator works')
+    })
+  })
 })


### PR DESCRIPTION
This PR enables experimental pipeline operator support in the parser. This is something we've been using in our project for a while now. If this is not something you'd like to include in the project feel free to close the PR, we'll stick to forked version in that case.