### PR TITLE
Add overrideContext configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 * Supports globs
 * Supports flow type
 * Supports string concatenation, e.g. `gettext('Foo ' + 'Bar')` (useful for wrapping into multiple lines)
+* Supports dynamically overriding message contexts.
 
 ## Usage
 
@@ -300,6 +301,46 @@ Default: `false`
 Does not break long strings into several lines
 
 Default: `false`
+
+##### `overrideContext`
+
+Overrides the context present in a component/function.
+
+This allows for dynamic creation of messages for contexts.
+
+Ex:
+
+```
+<GetText
+  message={'{{ name }} is very tall'}
+  context={gender}
+/>
+```
+
+Configured with 
+
+```
+const messages = extractMessages(code, {
+  overrideContext: ['male', 'female'],
+})
+```
+
+Would result in
+
+```
+#: src/App.js:37
+msgctxt "male"
+msgid "{{ name }} is very tall"
+msgstr ""
+
+#: src/App.js:37
+msgctxt "female"
+msgid "{{ name }} is very tall"
+msgstr ""
+```
+
+This allows your translation teams to create context specific translations, especially useful for languages that have variations based on gender.
+
 
 ### Configuration file
 

--- a/src/parse.js
+++ b/src/parse.js
@@ -448,6 +448,15 @@ export const extractMessages = (code, opts = {}) => {
     }))
   }
 
+  if (Array.isArray(opts.overrideContext) && opts.overrideContext.length > 0) {
+    blocks = opts.overrideContext.reduce((acc, override) => {
+      return [...acc, ...blocks.map(block => ({
+        ...block,
+        msgctxt: override
+      }))]
+    }, [])
+  }
+
   return blocks
 }
 

--- a/tests/fixtures/OverrideContext.js
+++ b/tests/fixtures/OverrideContext.js
@@ -1,0 +1,15 @@
+/* eslint react/prop-types: 0 */
+import React from 'react';
+import { GetText, npgettext } from 'gettext-lib';
+
+export const Comp = ({ value }) =>
+  <div>
+    <GetText
+      message={'Value is: {{ value }}'}
+      messagePlural={'Values are: {{ value }}'}
+      scope={{ value }}
+      comment={'Comment'}
+      context={'context'}
+    />
+
+  </div>;

--- a/tests/fixtures/OverrideContext.json
+++ b/tests/fixtures/OverrideContext.json
@@ -1,0 +1,18 @@
+[
+  {
+    "msgctxt": "foo",
+    "msgid": "Translate me",
+    "comments": {
+      "reference": [],
+      "extracted": []
+    }
+  },
+  {
+    "msgctxt": "bar",
+    "msgid": "Translate me",
+    "comments": {
+      "reference": [],
+      "extracted": []
+    }
+  }
+]

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -553,4 +553,17 @@ describe('react-gettext-parser', () => {
       expect(messages[0].msgid).to.equal('Pipeline operator works')
     })
   })
+
+  describe('context override support', () => {
+    it('should override context', () => {
+      const code = getSource('SingleString.jsx')
+      const messages = extractMessages(code, {
+        overrideContext: ['foo', 'bar'],
+      })
+      const expected = getJson('OverrideContext.json')
+      expect(messages).to.have.length(2)
+      expect(messages[0].msgctxt).to.equal(expected[0].msgctxt)
+      expect(messages[1].msgctxt).to.equal(expected[1].msgctxt)
+    })
+  })
 })

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -30,7 +30,6 @@ describe('react-gettext-parser', () => {
     it('should extract a message from jsx', () => {
       const code = getSource('SingleString.jsx')
       const messages = extractMessages(code)
-
       const expected = getJson('SingleString.json')
 
       expect(messages).to.have.length(1)
@@ -556,7 +555,7 @@ describe('react-gettext-parser', () => {
 
   describe('context override support', () => {
     it('should override context', () => {
-      const code = getSource('SingleString.jsx')
+      const code = getSource('OverrideContext.js')
       const messages = extractMessages(code, {
         overrideContext: ['foo', 'bar'],
       })


### PR DESCRIPTION
Adds ability to override context parsed from code with a list of overrides.

This is useful for the common case of languages that have variations based on gender where the usual approach with gettext is to use contexts for managing the gender variations.