### PR TITLE
Fix `colors` version to 1.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1648,9 +1648,9 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "colors": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
-      "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+      "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM="
     },
     "commander": {
       "version": "2.19.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@babel/parser": "^7.9.4",
     "@babel/traverse": "^7.3.4",
-    "colors": "^1.1.2",
+    "colors": "1.1.2",
     "convert-newline": "0.0.5",
     "gettext-parser": "^1.1.2",
     "glob-all": "^3.2.1",


### PR DESCRIPTION
Due to the happenings around the `colors` gem: a quick fix to get this package working again.

ref: https://snyk.io/blog/open-source-npm-packages-colors-faker/